### PR TITLE
Reify related objects etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Java CI](https://github.com/JKatzwinkel/tla-web/workflows/build/badge.svg)
-![LINE](https://img.shields.io/badge/line--coverage-91%25-brightgreen.svg)
-![METHOD](https://img.shields.io/badge/method--coverage-73%25-yellow.svg)
+![LINE](https://img.shields.io/badge/line--coverage-92%25-brightgreen.svg)
+![METHOD](https://img.shields.io/badge/method--coverage-74%25-yellow.svg)
 
 TLA web frontend.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Java CI](https://github.com/JKatzwinkel/tla-web/workflows/build/badge.svg)
 ![LINE](https://img.shields.io/badge/line--coverage-90%25-brightgreen.svg)
-![METHOD](https://img.shields.io/badge/method--coverage-67%25-yellow.svg)
+![METHOD](https://img.shields.io/badge/method--coverage-68%25-yellow.svg)
 
 TLA web frontend.
 

--- a/src/main/java/tla/web/model/Lemma.java
+++ b/src/main/java/tla/web/model/Lemma.java
@@ -8,15 +8,18 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.Singular;
 import lombok.experimental.SuperBuilder;
+import tla.domain.dto.LemmaDto;
 import tla.domain.model.Language;
 import tla.domain.model.Script;
 import tla.domain.model.extern.AttestedTimespan;
 import tla.domain.model.meta.BTSeClass;
+import tla.domain.model.meta.TLADTO;
 
 @Data
 @SuperBuilder
 @NoArgsConstructor
 @BackendPath("lemma")
+@TLADTO(LemmaDto.class)
 @BTSeClass("BTSLemmaEntry")
 @EqualsAndHashCode(callSuper = true)
 public class Lemma extends TLAObject {

--- a/src/main/java/tla/web/model/Lemma.java
+++ b/src/main/java/tla/web/model/Lemma.java
@@ -1,14 +1,20 @@
 package tla.web.model;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.stream.Collectors;
 
+import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.Singular;
 import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
+
 import tla.domain.dto.LemmaDto;
 import tla.domain.model.Language;
 import tla.domain.model.Script;
@@ -17,6 +23,7 @@ import tla.domain.model.meta.BTSeClass;
 import tla.domain.model.meta.TLADTO;
 
 @Data
+@Slf4j
 @SuperBuilder
 @NoArgsConstructor
 @BackendPath("lemma")
@@ -24,6 +31,14 @@ import tla.domain.model.meta.TLADTO;
 @BTSeClass("BTSLemmaEntry")
 @EqualsAndHashCode(callSuper = true)
 public class Lemma extends TLAObject {
+
+    /**
+     * The passport locator where bibliographical information should be stored.
+     */
+    public static final String PASSPORT_PROP_BIBL = "bibliography.bibliographical_text_field";
+
+    @Setter(AccessLevel.NONE)
+    private List<String> bibliography;
 
     @Singular
     private SortedMap<Language, List<String>> translations;
@@ -69,6 +84,50 @@ public class Lemma extends TLAObject {
             }
         }
         return null;
+    }
+
+    /**
+     * Returns a list of bibliographic references extracted from this lemma's
+     * <code>bibliography.bibliographical_text_field</code> passport field.
+     *
+     * @see {@link #extractBibliography(Lemma)}
+     */
+    public List<String> getBibliography() {
+        if (this.bibliography == null) {
+            this.bibliography = extractBibliography(this);
+        }
+        return this.bibliography;
+    }
+
+    /**
+     * Extract bibliographic information from lemma passport.
+     *
+     * Bibliography is being copied from the <code>bibliography.bibliographical_text_field</code>
+     * passport field. The value(s) found under that locator are split at semicolons <code>";"</code>.
+     *
+     * @param lemma The Lemma instance from whose passport the bibliography is to be extracted.
+     * @return List of textual bibliographic references or an empty list
+     */
+    private static List<String> extractBibliography(Lemma lemma) {
+        List<String> bibliography = new ArrayList<>();
+        try {
+            lemma.getPassport().extractProperty(
+                PASSPORT_PROP_BIBL
+            ).forEach(
+                node -> bibliography.addAll(
+                    Arrays.asList(
+                        node.getLeafNodeValue().split(";")
+                    ).stream().map(
+                        bibref -> bibref.strip()
+                    ).collect(
+                        Collectors.toList()
+                    )
+                )
+            );
+        } catch (Exception e) {
+            log.debug("could not extract bibliography from lemma {}", lemma.getId());
+        }
+        return bibliography;
     }
 
 }

--- a/src/main/java/tla/web/mvc/LemmaController.java
+++ b/src/main/java/tla/web/mvc/LemmaController.java
@@ -49,7 +49,6 @@ public class LemmaController extends ObjectController<Lemma> {
 
     @Override
     protected Model compileSingleObjectDetailsModel(Model model, ObjectDetails<Lemma> container) {
-        model.addAttribute("bibliography", lemmaService.extractBibliography(container.getObject()));
         model.addAttribute("annotations", lemmaService.extractAnnotations(container));
         return model;
     }

--- a/src/main/java/tla/web/mvc/ObjectController.java
+++ b/src/main/java/tla/web/mvc/ObjectController.java
@@ -59,7 +59,8 @@ public abstract class ObjectController<T extends TLAObject> {
             )
         );
         model.addAttribute("obj", container.getObject());
-        model.addAttribute("related", container.getRelatedObjects());
+        model.addAttribute("related", container.getRelated());
+        model.addAttribute("relations", container.extractRelatedObjects());
         return String.format("%s/details", getTemplatePath());
     }
 

--- a/src/main/java/tla/web/service/LemmaService.java
+++ b/src/main/java/tla/web/service/LemmaService.java
@@ -37,7 +37,7 @@ public class LemmaService extends ObjectService<Lemma> {
      * TODO: should probably be a method of the object details container itself.
      */
     public List<Annotation> extractAnnotations(ObjectDetails<Lemma> container) {
-        Map<String, Map<String, TLAObject>> related = container.getRelatedObjects();
+        Map<String, Map<String, TLAObject>> related = container.getRelated();
         if (related != null && related.containsKey("BTSAnnotation") && !related.get("BTSAnnotation").isEmpty()) {
             return related.get("BTSAnnotation").values().stream().map(
                 relatedObject -> relatedObject instanceof Annotation ? (Annotation) relatedObject : null

--- a/src/main/java/tla/web/service/LemmaService.java
+++ b/src/main/java/tla/web/service/LemmaService.java
@@ -48,35 +48,6 @@ public class LemmaService extends ObjectService<Lemma> {
         }
     }
 
-    /**
-     * Extract bibliographic information from lemma.
-     *
-     * @param lemma Lemma object from internal model
-     * @return list of textual bibliographic references or null
-     */
-    public List<String> extractBibliography(Lemma lemma) {
-        try {
-            List<String> bibliography = new ArrayList<>();
-            lemma.getPassport().extractProperty(
-                "bibliography.bibliographical_text_field"
-            ).forEach(
-                node -> bibliography.addAll(
-                    Arrays.asList(
-                        node.getLeafNodeValue().split(";")
-                    ).stream().map(
-                        bibref -> bibref.strip()
-                    ).collect(
-                        Collectors.toList()
-                    )
-                )
-            );
-            return bibliography;
-        } catch (Exception e) {
-            log.warn("could not extract bibliography from lemma {}", lemma.getId());
-            return null;
-        }
-    }
-
     public SearchResults search(LemmaSearch command, Integer page) {
         SearchResultsWrapper<DocumentDto> response = backend.lemmaSearch(command, page);
         SearchResults container = SearchResults.from(response);

--- a/src/main/java/tla/web/service/ObjectService.java
+++ b/src/main/java/tla/web/service/ObjectService.java
@@ -1,9 +1,14 @@
 package tla.web.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.springframework.beans.factory.annotation.Autowired;
 
 import tla.domain.dto.DocumentDto;
 import tla.domain.dto.extern.SingleDocumentWrapper;
+import tla.domain.model.ObjectReference;
 import tla.web.model.ObjectDetails;
 import tla.web.model.TLAObject;
 import tla.web.repo.TlaClient;
@@ -36,7 +41,7 @@ public abstract class ObjectService<T extends TLAObject> {
         );
         return new ObjectDetails<T>(
             (T) container.getObject(),
-            container.getRelatedObjects()
+            container.getRelated()
         );
     }
 

--- a/src/main/resources/static/css/tla-styles.css
+++ b/src/main/resources/static/css/tla-styles.css
@@ -823,17 +823,16 @@ footer.bg-light {
 }
 
 .id {
-    font-size: 1.5em;
     font-weight: 600;
-    padding: 0.6rem;
+    padding: 0em 0.2em;
     background-color: var(--BBAWlightbluegrey);
     color: white;
     display: inline-block;
 }
 
-.id h2 span {
+h2.id span {
     font-family: "BBAWLibertine" !important;
-    font-weight: 200;
+    padding: 0.6rem;
 }
 
 

--- a/src/main/resources/templates/base.html
+++ b/src/main/resources/templates/base.html
@@ -12,12 +12,12 @@
     <link rel="stylesheet" th:href="@{${env.bootstrapCss}}" href="../static/vendor/bootstrap-4.4.1-dist/css/bootstrap.min.css" type="text/css"/>
     <link rel="stylesheet" th:href="@{${env.fontawesomeCss}}" href="../static/vendor/fontawesome-free-5.7.0-web/css/all.css" type="text/css"/>
 
-    <script th:src="@{${env.bootstrapJs}}" src="../static/vendor/bootstrap-4.3.1-dist/js/bootstrap.min.js"></script>
-    <script th:src="@{${env.fontawesomeJs}}" src="../static/vendor/fontawesome-free-5.7.0-web/js/all.js"></script>
-
     <script th:src="@{/vendor/jquery.min.js}" src="../static/vendor/jquery.min.js"></script>
     <script th:src="@{/vendor/headroom.min.js}" src="../static/vendor/headroom.min.js"></script>
     <script th:src="@{/vendor/js.cookie.min.js}" src="../static/vendor/js.cookie.min.js"></script>
+
+    <script th:src="@{${env.bootstrapJs}}" src="../static/vendor/bootstrap-4.3.1-dist/js/bootstrap.min.js"></script>
+    <script th:src="@{${env.fontawesomeJs}}" src="../static/vendor/fontawesome-free-5.7.0-web/js/all.js"></script>
 
     <link rel="stylesheet" th:href="@{/css/tla-styles.css}" href="../static/css/tla-styles.css" type="text/css"/>
     <script th:src="@{/js/tla-functions.js}" src="../static/js/tla-functions.js"></script>

--- a/src/main/resources/templates/fragments/details.html
+++ b/src/main/resources/templates/fragments/details.html
@@ -177,7 +177,7 @@
     <!-- "Atoms" -->
 
     <!-- POS/type -->
-    <span th:fragment="lemma-pos">
+    <span th:fragment="lemma-pos" id="object-type-subtype">
         <span th:text="#{|pos_type_${obj.type}|}" class="lemma-type">Type</span>
         <span th:if="${obj.subtype}">
           (<span th:text="#{|pos_subtype_${obj.subtype}|}" class="lemma-subtype">Subtype</span>)

--- a/src/main/resources/templates/fragments/details.html
+++ b/src/main/resources/templates/fragments/details.html
@@ -60,12 +60,12 @@
     </div>
 
     <!-- bibliography -->
-    <div class="bibliography" th:fragment="bibliography" id="bibliography" th:if="${bibliography} != null">
+    <div class="bibliography" th:fragment="bibliography" id="bibliography" th:if="${obj.bibliography} != null">
         <hr/>
         <p>
             <strong th:text="#{object_property_bibliography}" class="details-property-label">Bibliography</strong>
             <br/>
-            <span th:each="bib : ${bibliography}">
+            <span th:each="bib : ${obj.bibliography}">
                 <span class="fas fa-arrow-circle-right"></span>
                 <span class="bibliographic-reference" th:text="${bib}"></span>
             </span>

--- a/src/main/resources/templates/fragments/details.html
+++ b/src/main/resources/templates/fragments/details.html
@@ -14,7 +14,7 @@
         <h2 class="id mt-1">
         <span class="bbaw-libertine" th:text="${obj.name}">Object name</span>
         </h2>
-        <a th:title="'Review status: ' + ${obj.reviewState}">
+        <a th:title="|Review status: ${obj.reviewState}|">
         <span class="solo-icon red-status float-right">
             <span class="fa-check-circle" th:classappend="${#strings.equals(obj.reviewState, 'published')} ? ok : pending">
             </span>
@@ -29,8 +29,8 @@
             <strong th:text="#{object_property_external_references}" class="details-property-label">External
                 references</strong>
         </p>
-        <div th:each="entry : ${obj.externalReferences}" class="align-items-start" th:id="'external-references-' + ${entry.key}">
-            <span th:text="#{'external_reference_provider_' + ${entry.key}}" class="external-reference-provider pr-2">Provider</span>
+        <div th:each="entry : ${obj.externalReferences}" class="align-items-start" th:id="|external-references-${entry.key}|">
+            <span th:text="#{|external_reference_provider_${entry.key}|}" class="external-reference-provider pr-2">Provider</span>
             <span class="external-reference" th:each="ref : ${entry.value}">
                 <a th:if="${ref.href} != null" th:href="${ref.href}">
                     <span class="fas fa-arrow-circle-right red"></span>
@@ -105,7 +105,7 @@
         </div>
         <div class="review-state">
             <strong class="details-property-label" th:text="#{object_property_review_state}">Review State:</strong>
-            <span th:text="#{'review_state_' + ${obj.reviewState}}">status</span>
+            <span th:text="#{|review_state_${obj.reviewState}|}">status</span>
         </div>
     </div>
 
@@ -132,7 +132,7 @@
     <div th:fragment="lemma-property-dict" id="lemma-property-dict">
         <hr/>
         <strong th:text="#{lemma_property_dict}" class="details-property-label">Dictionary:</strong>
-        <span th:text="#{'dict_' + ${obj.dictionaryName}}">Hieratic/Demotic/Coptic</span>
+        <span th:text="#{|dict_${obj.dictionaryName}|}">Hieratic/Demotic/Coptic</span>
     </div>
 
     <!-- Lemma Attestations -->
@@ -152,12 +152,12 @@
         <strong th:text="#{lemma_property_related_objects}" class="details-property-label">Related Lemmata</strong>
         <div class="row py-1" th:each="predicate : ${obj.relations}">
             <div class="pl-0 col-md-2">
-                <span th:text="#{${objectType} + '_relation_predicate_' + ${predicate.key}}" class="details-property-label">Predicate</span>
+                <span th:text="#{|${objectType}_relation_predicate_${predicate.key}|}" class="details-property-label">Predicate</span>
             </div>
             <div class="col-md-10">
                 <div class="d-flex justify-content-between" th:each="relatedObject : ${predicate.value}" th:object="${relatedObject}">
                     <span class="bbaw-libertine" th:text="*{name}"></span>
-                    <span th:text="'(' + *{id} + ')'"></span>
+                    <span th:text="|(*{id})|"></span>
                     <span th:text="*{eclass}"></span>
                     <span th:text="*{type}"/>
                 </div>
@@ -170,9 +170,9 @@
 
     <!-- POS/type -->
     <span th:fragment="lemma-pos" id="lemma-pos">
-        <span th:text="#{'pos_type_' + ${obj.type}}" class="lemma-type">Type</span>
+        <span th:text="#{|pos_type_${obj.type}|}" class="lemma-type">Type</span>
         <span th:if="${obj.subtype}">
-          (<span th:text="#{'pos_subtype_' + ${obj.subtype}}" class="lemma-subtype">Subtype</span>)
+          (<span th:text="#{|pos_subtype_${obj.subtype}|}" class="lemma-subtype">Subtype</span>)
         </span>
     </span>
 

--- a/src/main/resources/templates/fragments/details.html
+++ b/src/main/resources/templates/fragments/details.html
@@ -52,7 +52,7 @@
         </p>
         <div th:each="entry : ${obj.translations}">
             <p th:each="translation : ${entry.value}" th:class="'lemma-translation-' + ${entry.key}">
-                <span class="lang-icon" th:text="${#strings.toUpperCase(entry.key)}">DE</span>
+                <span class="lang-icon text-uppercase" th:text="${entry.key}">DE</span>
                 <span class="translation" th:text="${translation}">Translation</span>
             </p>
         </div>
@@ -101,7 +101,7 @@
         </div>
         <div class="updated">
             <strong class="details-property-label" th:text="#{object_property_editors_updated}">Updated</strong>
-            <span th:text="${obj.edited.updated}">date</span>
+            <span th:text="${#dates.formatISO(obj.edited.updated)}">date</span>
         </div>
         <div class="review-state">
             <strong class="details-property-label" th:text="#{object_property_review_state}">Review State:</strong>
@@ -121,10 +121,10 @@
     <!-- Lemma details hieroglyphs -->
     <div th:fragment="lemma-property-hieroglyphs" id="lemma-property-hieroglyphs" th:unless="${hieroglyphs} == null">
         <p>
-            <strong th:text="#{lemma_property_hieroglyphs}" class="details-property-label">Hieroglyphic spelling(s):</strong>
-            <span th:each="glyphs : ${hieroglyphs}">
-              <span class="hieroglyphs" th:title="${glyphs.mdc}" th:utext="${glyphs.svg}"/>
-            </span>
+          <strong th:text="#{lemma_property_hieroglyphs}" class="details-property-label">Hieroglyphic spelling(s):</strong>
+          <span th:each="glyphs : ${hieroglyphs}">
+            <span class="hieroglyphs" th:title="${glyphs.mdc}" th:utext="${glyphs.svg}" th:unless="${glyphs} == null"/>
+          </span>
         </p>
     </div>
 
@@ -147,19 +147,27 @@
     </div>
 
     <!-- Related Lemmata -->
-    <div th:fragment="lemma-property-related-objects" id="lemma-property-related-objects" th:unless="${#maps.isEmpty(obj.relations)}">
+    <div th:fragment="lemma-property-related-objects" id="lemma-property-related-objects" th:unless="${#maps.isEmpty(relations)}">
+
         <hr/>
         <strong th:text="#{lemma_property_related_objects}" class="details-property-label">Related Lemmata</strong>
-        <div class="row py-1" th:each="predicate : ${obj.relations}">
+        <div class="row py-1" th:each="predicate : ${relations}">
             <div class="pl-0 col-md-2">
                 <span th:text="#{|${objectType}_relation_predicate_${predicate.key}|}" class="details-property-label">Predicate</span>
             </div>
             <div class="col-md-10">
-                <div class="d-flex justify-content-between" th:each="relatedObject : ${predicate.value}" th:object="${relatedObject}">
-                    <span class="bbaw-libertine" th:text="*{name}"></span>
-                    <span th:text="|(*{id})|"></span>
-                    <span th:text="*{eclass}"></span>
-                    <span th:text="*{type}"/>
+                <div class="row related-object" th:each="relatedObject : ${predicate.value}" th:object="${relatedObject}" th:unless="${relatedObject.eclass} == 'BTSAnnotation'">
+                    <div class="col-sm d-flex  align-items-center">
+                      <span class="font-weight-bold bbaw-libertine" th:text="*{name}">nfr</span>
+                    <span class="col-sm">
+                      <span class="badge badge-secondary text-left text-wrap" th:text="|*{id}|">ID</span>
+                      <span class="badge badge-light" th:text=" #{|dict_*{dictionaryName}|}|">Script</span>
+                      </span>
+                    </div>
+                    <div class="col-sm d-flex align-items-center">
+                      <span th:each="translation : *{translations['de']}" th:text="${translation}">translation</span>
+                    </div>
+                    <div class="col-sm" th:text="*{type}"/>
                 </div>
             </div>
         </div>
@@ -169,7 +177,7 @@
     <!-- "Atoms" -->
 
     <!-- POS/type -->
-    <span th:fragment="lemma-pos" id="lemma-pos">
+    <span th:fragment="lemma-pos">
         <span th:text="#{|pos_type_${obj.type}|}" class="lemma-type">Type</span>
         <span th:if="${obj.subtype}">
           (<span th:text="#{|pos_subtype_${obj.subtype}|}" class="lemma-subtype">Subtype</span>)

--- a/src/main/resources/templates/fragments/search.html
+++ b/src/main/resources/templates/fragments/search.html
@@ -9,7 +9,7 @@
         <div class="col-xl-10">
           <div th:each="item : ${allScripts}" class="form-check form-check-inline">
             <input class="form-check-input" type="checkbox" th:field="*{script}" th:value="${item}"/>
-            <label class="form-check-label" th:for="${#ids.prev('script')}" th:text="#{'dict_' + ${item}}"/>
+            <label class="form-check-label" th:for="${#ids.prev('script')}" th:text="#{|dict_${item}|}"/>
           </div>
         </div>
       </div>
@@ -36,7 +36,7 @@
           <input class="form-control mb-3" type="text" th:field="*{translation.text}" name="translation"/>
           <div th:each="lang : ${allTranslationLanguages}" class="form-check form-check-inline">
             <input class="form-check-input" type="checkbox" th:field="*{translation.lang}" th:value="${lang}"/>
-            <label class="form-check-label" th:for="${#ids.prev('translation.lang')}" th:text="#{'lang_label_' + ${lang}}">Language</label>
+            <label class="form-check-label" th:for="${#ids.prev('translation.lang')}" th:text="#{|lang_label_${lang}|}">Language</label>
           </div>
         </div>
       </div>
@@ -58,19 +58,19 @@
     <!-- Type / Subtype selection multi-dropdown composite -->
 
       <div class="form-group row bg-grey" th:fragment="type-spec(name, bind, typeMap)" th:object="${__${bind}__}">
-        <label class="col-form-label col-xl-2" th:for="${name} + '-type'" th:text="#{'field_label_' + ${name} + '_type'}">Type/Subtype specification</label>
+        <label class="col-form-label col-xl-2" th:for="|${name}-type|" th:text="#{|field_label_${name}_type|}">Type/Subtype specification</label>
         <div class="col-xl-10">
-          <select class="form-control" th:id="${name} + '-type'" name="word-class-type" th:field="*{type}">
-            <option th:each="type : ${typeMap}" th:value="${type.key}" th:text="#{'field_value_label_' + ${name} + '_type_' + ${type.key}}">Type</option>
+          <select class="form-control" th:id="|${name}-type|" name="word-class-type" th:field="*{type}">
+            <option th:each="type : ${typeMap}" th:value="${type.key}" th:text="#{|field_value_label_${name}_type_${type.key}|}">Type</option>
           </select>
           <!-- create hidden subtype menu for each type -->
-          <select th:unless="${#lists.isEmpty(type.value)}" th:each="type : ${typeMap}" th:id="${name} + '-type-hidden-options-' + ${type.key}" hidden="true">
-            <option th:each="subtype : ${type.value}" th:value="${subtype}" th:text="#{'field_value_label_' + ${name} + '_subtype_' + ${subtype}}">Subtype</option>
+          <select th:unless="${#lists.isEmpty(type.value)}" th:each="type : ${typeMap}" th:id="|${name}-type-hidden-options-${type.key}|" hidden="true">
+            <option th:each="subtype : ${type.value}" th:value="${subtype}" th:text="#{|field_value_label_${name}_subtype_${subtype}|}">Subtype</option>
           </select>
         </div>
-        <label class="col-form-label col-xl-2" th:for="${name} + '-subtype'" th:text="#{'field_label_' + ${name} + '_subtype'}">Subtype</label>
+        <label class="col-form-label col-xl-2" th:for="|${name}-subtype|" th:text="#{|field_label_${name}_subtype|}">Subtype</label>
         <div class="col-xl-10">
-          <select class="form-control" th:id="${name} + '-subtype'" th:name="${name} + '-subtype'" th:field="*{subtype}">
+          <select class="form-control" th:id="|${name}-subtype|" th:name="|${name}-subtype|" th:field="*{subtype}">
             <script th:inline="javascript">
               //<![CDATA[
               function populateSubTypeDropDown(name) {

--- a/src/main/resources/templates/lemma/details.html
+++ b/src/main/resources/templates/lemma/details.html
@@ -28,7 +28,7 @@
               <button type="button" class="btn btn-light btn-sm text-left text-decoration-none copy-to-clipboard-btn" onclick="copyStringToClipboard('{{obj.id}}')"><span class="fas fa-clipboard"></span>Copy ID</button>
               <br/>
               <strong>Persistent URL:</strong>
-              <span th:text="${env.baseUrl} + '/lemma/' + ${obj.id}">http://tla.bbaw.de/lemma/xxx</span>
+              <span th:text="|${env.baseUrl}/lemma/${obj.id}|">http://tla.bbaw.de/lemma/xxx</span>
               <button type="button" class="btn btn-light btn-sm text-left text-decoration-none copy-to-clipboard-btn" onclick="copyStringToClipboard('TLA lemma ID {{obj.id}} ({{obj.name}}), &lt;{{env.baseUrl}}/lemma/{{obj.id}}&gt;, in: {{tlaTitle}} &lt;{{tlaBaseURL}}&gt;, Version {{tlaVersion}}.{{tlaIssue}}, {{tlaReleaseDate}}, ed. by {{tlaEditor}} (accessed: {{dateToday}})');">
                 <span class="fas fa-clipboard"></span>Copy citation
               </button>

--- a/src/test/java/tla/web/model/LemmaTest.java
+++ b/src/test/java/tla/web/model/LemmaTest.java
@@ -5,6 +5,8 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
+import tla.domain.model.Passport;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class LemmaTest {
@@ -41,4 +43,32 @@ public class LemmaTest {
         );
     }
 
+    @Test
+    void getBibliography() throws Exception {
+        Passport p = new Passport();
+        Passport b = new Passport();
+        b.add(
+            "bibliographical_text_field",
+            new Passport(
+                "Wb 1, 130.1-5; Germer, Flora, 125; LÄ II, 1265"
+            )
+        );
+        p.add("bibliography", b);
+        assertAll("test passport",
+            () -> assertTrue(!b.isEmpty(), "subnode not empty"),
+            () -> assertTrue(b.containsKey("bibliographical_text_field"), "subnode key"),
+            () -> assertEquals(1, p.size(), "root size"),
+            () -> assertEquals(List.of("bibliography"), p.getFields(), "root keys"),
+            () -> assertTrue(p.containsKey("bibliography"), "root key"),
+            () -> assertTrue(!p.getProperties().get("bibliography").isEmpty(), "subnodes exist"),
+            () -> assertTrue(p.getProperties().get("bibliography").get(0).containsKey("bibliographical_text_field"))
+        );
+        Lemma l = Lemma.builder().passport(p).build();
+        assertAll("see if bibliography can be extracted",
+            () -> assertNotNull(l.getBibliography(), "bibliography not null"),
+            () -> assertTrue(!l.getBibliography().isEmpty(), "bibl not empty"),
+            () -> assertEquals(3, l.getBibliography().size(), "3 bibl entries"),
+            () -> assertEquals("Germer, Flora, 125", l.getBibliography().get(1), "value trimmed")
+        );
+    }
 }

--- a/src/test/java/tla/web/mvc/LemmaDetailsTest.java
+++ b/src/test/java/tla/web/mvc/LemmaDetailsTest.java
@@ -77,7 +77,7 @@ public class LemmaDetailsTest {
         testResponse.andExpect(
             xpath("//div[@id='lemma-property-part-of-speech']").exists()
         ).andExpect(
-            xpath("//span[@id='lemma-pos']").exists()
+            xpath("//div[@id='lemma-property-part-of-speech']//span[@id='object-type-subtype']").exists()
         );
     }
 

--- a/src/test/java/tla/web/mvc/LemmaDetailsTest.java
+++ b/src/test/java/tla/web/mvc/LemmaDetailsTest.java
@@ -96,6 +96,12 @@ public class LemmaDetailsTest extends ViewTest {
             xpath("//div[@id='lemma-property-part-of-speech']//span[@id='object-type-subtype']").exists()
         ).andExpect(
             xpath("//div[@id='details-content']/div[@id='lemma-property-attestations']").exists()
+        ).andExpect(
+            xpath("//div[contains(@class,'bibliography')]/p/span/span[contains(@class,'bibliographic-reference')]").nodeCount(3)
+		).andExpect(
+            xpath("//div[contains(@class,'bibliography')]/p/span/span[contains(@class,'bibliographic-reference')]/text()").string(
+                "Wb 1, 130.1-5"
+            )
         );
     }
 

--- a/src/test/java/tla/web/service/ServiceTest.java
+++ b/src/test/java/tla/web/service/ServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,9 +47,15 @@ public class ServiceTest {
         assertTrue(objectDetails.getObject() instanceof Lemma);
         ObjectDetails<Lemma> lemmaDetails = new ObjectDetails<Lemma>(
             (Lemma) objectDetails.getObject(),
-            objectDetails.getRelatedObjects()
+            objectDetails.getRelated()
         );
         assertNotNull(lemmaDetails);
+        Map<String, List<TLAObject>> relatedObjects = lemmaDetails.extractRelatedObjects();
+        assertAll("test related objects extraction",
+            () -> assertEquals(dto.getDoc().getRelations().size(), relatedObjects.size(), "predicate count"),
+            () -> assertEquals(2, relatedObjects.get("contains").size(), "relations of predicate 'contains'"),
+            () -> assertTrue(relatedObjects.get("contains").get(0) instanceof Annotation, "reference reified to Annotation instance")
+        );
         List<Annotation> annotations = lemmaService.extractAnnotations(lemmaDetails);
         assertAll("test lemma annotations extraction",
             () -> assertNotNull(annotations),


### PR DESCRIPTION
- mirror domain object `relations` field, but replace `ObjectReference` previews with the actual objects from the object details DTO's related objects directory. (26cf549)
- move lemma bibliography extraction from service to domain model class itself (cdd393d)
- make better use of thymeleaf string interpolation syntax (d9d1171)