### PR TITLE
Editorial content management ("statische Texte")

### DIFF
--- a/src/main/java/tla/web/config/EditorialConfig.java
+++ b/src/main/java/tla/web/config/EditorialConfig.java
@@ -1,0 +1,114 @@
+package tla.web.config;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.io.Resource;
+import org.thymeleaf.templatemode.TemplateMode;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Configuration
+public class EditorialConfig {
+
+    @Value("classpath:${tla.editorials.path}")
+    private Resource editorialsDir;
+
+    @Value("classpath:${tla.editorials.path}/**/*.html")
+    private Resource[] editorialFiles;
+
+    private EditorialRegistry editorialRegistry = new EditorialRegistry();
+
+    @Bean
+    public EditorialRegistry EditorialRegistry() {
+        return this.editorialRegistry;
+    }
+
+    @Bean
+    public ClassLoaderTemplateResolver editorialTemplatesResolver() {
+        ClassLoaderTemplateResolver resolver = new ClassLoaderTemplateResolver();
+        resolver.setSuffix(".html");
+        resolver.setPrefix("pages/");
+        resolver.setTemplateMode(TemplateMode.HTML);
+        resolver.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        resolver.setCheckExistence(true);
+        resolver.setOrder(1);
+        return resolver;
+    }
+
+    @Getter
+    public class EditorialRegistry {
+
+        private Map<String, Set<String>> langSupport = new HashMap<>();
+
+        private Path getRelativeEditorialPath(Resource editorialResource) throws IOException {
+            return Paths.get(
+                editorialsDir.getURI()
+            ).relativize(
+                Paths.get(editorialResource.getURI())
+            );
+        }
+
+        private String getEditorialPathLang(Path editorialPath) {
+            return editorialPath.subpath(0, 1).toString();
+        }
+
+        private String getEditorialPathMapping(Path editorialPath) {
+            Path path = editorialPath.subpath(
+                1,
+                editorialPath.getNameCount()
+            );
+            return path.toString().replaceAll("\\.[Hh][Tt][Mm][Ll]$", "");
+        }
+
+        private void registerEditorialFile(Resource editorialResource) {
+            try {
+                Path editorialPath = this.getRelativeEditorialPath(editorialResource);
+                String editorialID = this.getEditorialPathMapping(editorialPath);
+                String lang = this.getEditorialPathLang(editorialPath);
+                this.langSupport.putIfAbsent(
+                    editorialID,
+                    new TreeSet<>()
+                );
+                this.langSupport.get(editorialID).add(lang);
+            } catch (Exception e) {
+                log.error("could not register editorial resource {}!", editorialResource);
+                log.error("reason: ", e);
+            }
+        }
+
+        public Map<String, Set<String>> registerAll(Resource[] editorialResources) {
+            for (Resource r : editorialResources) {
+                this.registerEditorialFile(r);
+            }
+            return this.langSupport;
+        }
+    }
+
+    @EventListener
+    public void onContextRefresh(ContextRefreshedEvent event) throws IOException, NoSuchMethodException {
+        log.info("register editorial templates");
+        log.info("editorials dir: {}", editorialsDir);
+        if (editorialFiles != null) {
+            log.info(
+                "registry: {}",
+                this.editorialRegistry.registerAll(editorialFiles)
+            );
+        }
+    }
+
+}

--- a/src/main/java/tla/web/config/EditorialConfig.java
+++ b/src/main/java/tla/web/config/EditorialConfig.java
@@ -50,6 +50,9 @@ public class EditorialConfig {
     @Getter
     public class EditorialRegistry {
 
+        @Value("${tla.editorials.lang-default}")
+        private String langDefault;
+
         private Map<String, Set<String>> langSupport = new HashMap<>();
 
         private Path getRelativeEditorialPath(Resource editorialResource) throws IOException {
@@ -102,16 +105,19 @@ public class EditorialConfig {
          */
         public Set<String> getSupportedLanguages(String path) {
             return this.langSupport.getOrDefault(
-                path.substring(path.startsWith("/") ? 1 : 0),
-                Set.of("en")
-            ); // TODO default
+                path.substring(
+                    path.startsWith("/") ? 1 : 0
+                ),
+                Set.of(
+                    this.langDefault
+                )
+            );
         }
     }
 
     @EventListener
     public void onContextRefresh(ContextRefreshedEvent event) {
-        log.info("register editorial templates");
-        log.info("editorials dir: {}", editorialsDir);
+        log.info("register editorial templates inside of editorials dir {}.", editorialsDir);
         if (editorialFiles != null) {
             log.info(
                 "registry: {}",

--- a/src/main/java/tla/web/config/EditorialConfig.java
+++ b/src/main/java/tla/web/config/EditorialConfig.java
@@ -1,7 +1,6 @@
 package tla.web.config;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -67,8 +66,7 @@ public class EditorialConfig {
 
         private String getEditorialPathMapping(Path editorialPath) {
             Path path = editorialPath.subpath(
-                1,
-                editorialPath.getNameCount()
+                1, editorialPath.getNameCount()
             );
             return path.toString().replaceAll("\\.[Hh][Tt][Mm][Ll]$", "");
         }
@@ -89,16 +87,29 @@ public class EditorialConfig {
             }
         }
 
+        /**
+         * Registers a whole bunch of <pre>HTML</pre> files.
+         */
         public Map<String, Set<String>> registerAll(Resource[] editorialResources) {
             for (Resource r : editorialResources) {
                 this.registerEditorialFile(r);
             }
             return this.langSupport;
         }
+
+        /**
+         * Looks up the languages in which a given editorial page is available.
+         */
+        public Set<String> getSupportedLanguages(String path) {
+            return this.langSupport.getOrDefault(
+                path.substring(path.startsWith("/") ? 1 : 0),
+                Set.of("en")
+            ); // TODO default
+        }
     }
 
     @EventListener
-    public void onContextRefresh(ContextRefreshedEvent event) throws IOException, NoSuchMethodException {
+    public void onContextRefresh(ContextRefreshedEvent event) {
         log.info("register editorial templates");
         log.info("editorials dir: {}", editorialsDir);
         if (editorialFiles != null) {

--- a/src/main/java/tla/web/config/EditorialConfig.java
+++ b/src/main/java/tla/web/config/EditorialConfig.java
@@ -15,12 +15,18 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.io.Resource;
-import org.thymeleaf.templatemode.TemplateMode;
-import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Maintains an inventory of semi-static templates written for editorial web pages.
+ * Runs when the {@link ContextRefreshedEvent} is being broadcasted, and registers
+ * all <pre>HTML</pre> files inside of the directory specified via the
+ * <pre>tla.editorials.path</pre> application property, alongside their respective
+ * available languages.
+ * The registry is then added to the context in the {@link EditorialRegistry} bean.
+ */
 @Slf4j
 @Configuration
 public class EditorialConfig {
@@ -38,18 +44,10 @@ public class EditorialConfig {
         return this.editorialRegistry;
     }
 
-    @Bean
-    public ClassLoaderTemplateResolver editorialTemplatesResolver() {
-        ClassLoaderTemplateResolver resolver = new ClassLoaderTemplateResolver();
-        resolver.setSuffix(".html");
-        resolver.setPrefix("pages/");
-        resolver.setTemplateMode(TemplateMode.HTML);
-        resolver.setCharacterEncoding(StandardCharsets.UTF_8.name());
-        resolver.setCheckExistence(true);
-        resolver.setOrder(1);
-        return resolver;
-    }
-
+    /**
+     * Contains an inventory of all editorial pages and the languages in which they
+     * are available.
+     */
     @Getter
     public class EditorialRegistry {
 

--- a/src/main/java/tla/web/mvc/EditorialContentController.java
+++ b/src/main/java/tla/web/mvc/EditorialContentController.java
@@ -1,14 +1,22 @@
 package tla.web.mvc;
 
 import java.lang.reflect.Method;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
@@ -18,6 +26,7 @@ import tla.web.config.EditorialConfig.EditorialRegistry;
 
 @Slf4j
 @Controller
+@RequestMapping("/")
 public class EditorialContentController {
 
     @Autowired
@@ -27,23 +36,73 @@ public class EditorialContentController {
     private RequestMappingHandlerMapping handlerMapping;
 
     /**
+     * Select one of the languages in which a requested editorial page is available
+     * under consideration of the <pre>Appect-Language</pre> values passed.
+     */
+    private String negiotiateContentLanguage(String path, HttpHeaders header) {
+        List<Locale.LanguageRange> requested = header.getAcceptLanguage();
+        requested.sort(
+            Comparator.comparing(Locale.LanguageRange::getWeight)
+        );
+        log.info("accepted languages: {}", requested);
+        Set<String> supported = editorialRegistry.getSupportedLanguages(
+            path
+        );
+        log.info("supported languages for {}: {}", path, supported);
+        for (Locale.LanguageRange lang : requested) {
+            log.info("lang: {}, weight: {}", lang, lang.getWeight());
+            if (supported.contains(lang.toString())) {
+                return lang.toString();
+            }
+        }
+        return "en"; // TODO default
+    }
+
+    /**
+     * Puts together the path where to find the negoriated template.
+     */
+    private String templatePath(String lang, String path) {
+        return "../pages/" + lang + path;
+    }
+
+    /**
      * Generic handler for semi-static editorial HTML page requests.
      */
-    public String renderEditorial(HttpServletRequest request, Model model) throws Exception {
+    public String renderEditorial(
+        HttpServletRequest request,
+        @RequestHeader HttpHeaders header,
+        HttpServletResponse response,
+        Model model
+    ) throws Exception {
         String path = request.getRequestURI();
+        String contentLang = negiotiateContentLanguage(path, header);
         log.info("handling request for static page {}", path);
-        log.info("accepted language: {}", request.getHeader("Accept-Language"));
-        model.addAttribute("templatePath", path);
+        log.info("accepted language: {}", request.getHeader(HttpHeaders.ACCEPT_LANGUAGE));
+        log.info("negotiated language: {}", contentLang);
+        String tp = templatePath(contentLang, path);
+        log.info("template path: {}", tp);
+        model.addAttribute("templatePath", tp);
+        model.addAttribute("contentLang", contentLang);
+        // setting content lang header value does not have any effect for whatever reason
+        // response.addHeader(
+        //     HttpHeaders.CONTENT_LANGUAGE,
+        //     contentLang
+        // );
         return "editorial";
     }
 
+    /**
+     * Creates request handler mappings for editorial pages previously registered in the
+     * {@link EditorialRegistry}.
+     */
     @EventListener
     public void onApplicationReady(ApplicationReadyEvent event) throws NoSuchMethodException {
         log.info("ready to create request handler mappings for editorial templates");
-        log.info("editorial language support registry: {}", editorialRegistry.getLangSupport());
         Method handlerMethod = EditorialContentController.class.getDeclaredMethod(
             "renderEditorial",
             HttpServletRequest.class,
+            HttpHeaders.class,
+            HttpServletResponse.class,
             Model.class
         );
         try {
@@ -58,6 +117,5 @@ public class EditorialContentController {
             );
         } catch (Exception e) {}
     }
-
 
 }

--- a/src/main/java/tla/web/mvc/EditorialContentController.java
+++ b/src/main/java/tla/web/mvc/EditorialContentController.java
@@ -1,0 +1,63 @@
+package tla.web.mvc;
+
+import java.lang.reflect.Method;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import lombok.extern.slf4j.Slf4j;
+import tla.web.config.EditorialConfig.EditorialRegistry;
+
+@Slf4j
+@Controller
+public class EditorialContentController {
+
+    @Autowired
+    private EditorialRegistry editorialRegistry;
+
+    @Autowired
+    private RequestMappingHandlerMapping handlerMapping;
+
+    /**
+     * Generic handler for semi-static editorial HTML page requests.
+     */
+    public String renderEditorial(HttpServletRequest request, Model model) throws Exception {
+        String path = request.getRequestURI();
+        log.info("handling request for static page {}", path);
+        log.info("accepted language: {}", request.getHeader("Accept-Language"));
+        model.addAttribute("templatePath", path);
+        return "editorial";
+    }
+
+    @EventListener
+    public void onApplicationReady(ApplicationReadyEvent event) throws NoSuchMethodException {
+        log.info("ready to create request handler mappings for editorial templates");
+        log.info("editorial language support registry: {}", editorialRegistry.getLangSupport());
+        Method handlerMethod = EditorialContentController.class.getDeclaredMethod(
+            "renderEditorial",
+            HttpServletRequest.class,
+            Model.class
+        );
+        try {
+            this.editorialRegistry.getLangSupport().forEach(
+                (path, supportedLanguages) -> {
+                    handlerMapping.registerMapping(
+                        RequestMappingInfo.paths(path).methods(RequestMethod.GET).build(),
+                        this,
+                        handlerMethod
+                    );
+                }
+            );
+        } catch (Exception e) {}
+    }
+
+
+}

--- a/src/main/java/tla/web/mvc/GlobalControllerAdvisor.java
+++ b/src/main/java/tla/web/mvc/GlobalControllerAdvisor.java
@@ -43,7 +43,6 @@ public class GlobalControllerAdvisor extends DefaultHandlerExceptionResolver {
         );
     }
 
-
     @ExceptionHandler(ObjectNotFoundException.class)
     public ModelAndView handleObjectNotFound(ObjectNotFoundException e, HttpServletRequest request, Model model) {
         model.addAttribute("env", appVars());
@@ -63,6 +62,7 @@ public class GlobalControllerAdvisor extends DefaultHandlerExceptionResolver {
 
     @ExceptionHandler(Exception.class)
     public ModelAndView handleAnything(Exception e, HttpServletRequest request, Model model) {
+        model.addAttribute("env", appVars());
         model.addAttribute("code", 500);
         model.addAttribute("name", e.getClass().getCanonicalName());
         model.addAttribute("url", request.getRequestURI());

--- a/src/main/java/tla/web/mvc/ObjectController.java
+++ b/src/main/java/tla/web/mvc/ObjectController.java
@@ -42,8 +42,18 @@ public abstract class ObjectController<T extends TLAObject> {
         return this.templatePath;
     }
 
+    /**
+     * Must return an appropriate {@link ObjectService} instance for a particular controller
+     * to be able to invoke operations targeting the entity model class it has been typed for.
+     * @return An {@link ObjectService} instance providing access to entities of the specific type
+     * required by this controller.
+     */
     public abstract ObjectService<T> getService();
 
+    /**
+     * Retrieves the requested plus relevant related entites, and renders the results into the
+     * single object details template defined for the entity type supported.
+     */
     @RequestMapping(value = "/{id}", method = RequestMethod.GET)
     public String getSingleObjectDetailsPage(@PathVariable String id, Model model) {
         log.debug("Compile lemma detail view data for {} {}", getTemplatePath(), id);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,9 @@ tla:
     name: Thesaurus Linguae Aegyptiae (BETA)
     base-url: https://tla.bbaw.de
     backend-url: http://localhost:${BACKEND_PORT:8090}
+    editorials:
+        path: pages
+        default-lang: en
 
     link-formatters:
         aaew:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -129,7 +129,9 @@ spring:
         prefix: file:./src/main/resources/templates/
         check-template-location: true
     resources:
-        static-locations: file:./src/main/resources/static/
+        static-locations:
+          - file:./src/main/resources/static/
+          - file:./src/main/resources/pages/
         cache:
             period: 0
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ tla:
     backend-url: http://localhost:${BACKEND_PORT:8090}
     editorials:
         path: pages
-        default-lang: en
+        lang-default: en
 
     link-formatters:
         aaew:

--- a/src/main/resources/pages/de/legal/imprint.html
+++ b/src/main/resources/pages/de/legal/imprint.html
@@ -1,5 +1,4 @@
-<html>
-  <body>
+<article>
 
     <h3>Veröffentlicht von:</h3>
     <address>
@@ -14,7 +13,7 @@
     <h4>Vertreten durch:</h4>
     <address>
       Prof. Dr. Dr. h. c. mult. Martin Grötschel<br/>
-      <a href="tel:+49030203700">Tel.: +49 (0)30 20370-0</a>,
+      <a href="tel:+4930-20370-0">Tel.: +49 (0)30 20370-0</a>,
       <a href="mailto:bbaw@bbaw.de">E-Mail: bbaw@bbaw.de</a>
     </address>
 
@@ -54,5 +53,4 @@
       10117 Berlin
     </address>
 
-  </body>
-</html>
+</article>

--- a/src/main/resources/pages/de/legal/imprint.html
+++ b/src/main/resources/pages/de/legal/imprint.html
@@ -1,0 +1,58 @@
+<html>
+  <body>
+
+    <h3>Veröffentlicht von:</h3>
+    <address>
+      <a href="http://www.bbaw.de/en/" target="_blank">
+        Berlin-Brandenburgische Akademie der Wissenschaften
+      </a>
+      <br/>
+      Jägerstraße 22/23<br/>
+      10117 Berlin
+    </address>
+
+    <h4>Vertreten durch:</h4>
+    <address>
+      Prof. Dr. Dr. h. c. mult. Martin Grötschel<br/>
+      <a href="tel:+49030203700">Tel.: +49 (0)30 20370-0</a>,
+      <a href="mailto:bbaw@bbaw.de">E-Mail: bbaw@bbaw.de</a>
+    </address>
+
+    <h3>Rechtsform:</h3>
+    <p>
+      Rechtsfähige Körperschaft öffentlichen Rechts
+    </p>
+
+    <h3>Herausgeber:</h3>
+    <p>
+      Prof. Dr. Tonio Sebastian Richter &amp; Dr. Daniel A. Werning im Auftrag der
+      <a href="http://www.bbaw.de/en/" target="_blank">
+        Berlin-Brandenburgischen Akademie der Wissenschaften
+      </a>
+    </p>
+    <p>
+      Prof. Dr. Hans-Werner Fischer-Elfert &amp; Dr. Peter Dils im Auftrag der
+      <a href="https://www.saw-leipzig.de/en" target="_blank">
+        Sächsischen Akademie der Wissenschaften zu Leipzig
+      </a>
+    </p>
+
+    <h4>Geschäftsführung:</h4>
+    <address>
+      <a href="http://www.bbaw.de/die-akademie/mitarbeiter/werning" target="_blank">
+        Daniel Werning
+      </a>
+      (Arbeitsstellenleiter)
+      <br/>
+      Akademienprojekt
+      <a class="more" href="http://www.bbaw.de/en/research/aew">
+        Strukturen und Transformationen des Wortschatzes der ägyptischen Sprache. Text- und Wissenskultur im alten Ägypten
+      </a>
+      <br/>
+      Berlin-Brandenburgische Akademie der Wissenschaften<br/>
+      Unter den Linden 8<br/>
+      10117 Berlin
+    </address>
+
+  </body>
+</html>

--- a/src/main/resources/pages/en/legal/imprint.html
+++ b/src/main/resources/pages/en/legal/imprint.html
@@ -1,0 +1,63 @@
+<html>
+  <body>
+
+    <h3>Published by:</h3>
+    <address>
+      <a href="http://www.bbaw.de/en/" target="_blank">
+        Berlin-Brandenburgische Akademie der Wissenschaften
+      </a>
+      <br/>
+      Jägerstraße 22/23<br/>
+      10117 Berlin
+    </address>
+
+    <h4>Represented by:</h4>
+    <address>
+      Prof. Dr. Dr. h. c. mult. Martin Grötschel<br/>
+      <a href="tel:+49030203700">Tel.: +49 (0)30 20370-0</a>,
+      <a href="mailto:bbaw@bbaw.de">E-Mail: bbaw@bbaw.de</a>
+    </address>
+
+    <h3>Legal status:</h3>
+    <p>
+      Public law legal entity (Rechtsfähige Körperschaft öffentlichen Rechts)
+    </p>
+
+    <h4>VAT Identification No.:</h4>
+    <p>
+      DE 167 449 058 (according to &sect;27 a of the Value Added Tax Law of the Federal Republic of Germany)
+    </p>
+
+    <h3>Edited by:</h3>
+    <p>
+      Prof. Dr. Tonio Sebastian Richter &amp; Dr. Daniel A. Werning by order of the
+      <a href="http://www.bbaw.de/en/" target="_blank">
+        Berlin-Brandenburgische Akademie der Wissenschaften
+      </a>
+    </p>
+    <p>
+      Prof. Dr. Hans-Werner Fischer-Elfert &amp; Dr. Peter Dils by order of the
+      <a href="https://www.saw-leipzig.de/en" target="_blank">
+        Sächsische Akademie der Wissenschaften zu Leipzig
+      </a>
+    </p>
+
+    <h4>Executive editor:</h4>
+    <address>
+      <a href="http://www.bbaw.de/die-akademie/mitarbeiter/werning" target="_blank">
+        Daniel Werning
+      </a>
+      (Research Coordinator)
+      <br/>
+      Academies' project
+      <a class="more" href="http://www.bbaw.de/en/research/aew">
+        Strukturen und Transformationen des Wortschatzes der ägyptischen Sprache. Text- und Wissenskultur im alten Ägypten
+      </a>
+      <br/>
+      Berlin-Brandenburgische Akademie der Wissenschaften<br/>
+      Unter den Linden 8<br/>
+      10117 Berlin
+    </address>
+
+  </body>
+</html>

--- a/src/main/resources/pages/en/legal/imprint.html
+++ b/src/main/resources/pages/en/legal/imprint.html
@@ -1,34 +1,42 @@
-<html>
-  <body>
+<article>
 
-    <h3>Published by:</h3>
-    <address>
+  <section>
+    <h2>Published by:</h2>
+    <p>
       <a href="http://www.bbaw.de/en/" target="_blank">
         Berlin-Brandenburgische Akademie der Wissenschaften
       </a>
       <br/>
       Jägerstraße 22/23<br/>
       10117 Berlin
-    </address>
+    </p>
+  </section>
 
-    <h4>Represented by:</h4>
-    <address>
+  <section>
+    <h2>Represented by:</h2>
+    <p>
       Prof. Dr. Dr. h. c. mult. Martin Grötschel<br/>
-      <a href="tel:+49030203700">Tel.: +49 (0)30 20370-0</a>,
-      <a href="mailto:bbaw@bbaw.de">E-Mail: bbaw@bbaw.de</a>
-    </address>
+      Tel.: <a href="tel:+4930-20370-0">+49 (0)30 20370-0</a>,
+      E-Mail: <a href="mailto:bbaw@bbaw.de">bbaw@bbaw.de</a>
+    </p>
+  </section>
 
-    <h3>Legal status:</h3>
+  <section>
+    <h2>Legal status:</h2>
     <p>
       Public law legal entity (Rechtsfähige Körperschaft öffentlichen Rechts)
     </p>
+  </section>
 
-    <h4>VAT Identification No.:</h4>
+  <section>
+    <h2>VAT Identification No.:</h2>
     <p>
-      DE 167 449 058 (according to &sect;27 a of the Value Added Tax Law of the Federal Republic of Germany)
+      DE 167 449 058 (according to § 27 a of the Value Added Tax Law of the Federal Republic of Germany)
     </p>
+  </section>
 
-    <h3>Edited by:</h3>
+  <section>
+    <h2>Edited by:</h2>
     <p>
       Prof. Dr. Tonio Sebastian Richter &amp; Dr. Daniel A. Werning by order of the
       <a href="http://www.bbaw.de/en/" target="_blank">
@@ -42,22 +50,55 @@
       </a>
     </p>
 
-    <h4>Executive editor:</h4>
-    <address>
-      <a href="http://www.bbaw.de/die-akademie/mitarbeiter/werning" target="_blank">
-        Daniel Werning
-      </a>
-      (Research Coordinator)
-      <br/>
-      Academies' project
-      <a class="more" href="http://www.bbaw.de/en/research/aew">
-        Strukturen und Transformationen des Wortschatzes der ägyptischen Sprache. Text- und Wissenskultur im alten Ägypten
-      </a>
-      <br/>
-      Berlin-Brandenburgische Akademie der Wissenschaften<br/>
-      Unter den Linden 8<br/>
-      10117 Berlin
-    </address>
+    <section>
+      <h3>Executive editor:</h3>
+      <address>
+        <a href="http://www.bbaw.de/die-akademie/mitarbeiter/werning" target="_blank">
+          Daniel Werning
+        </a>
+        (Research Coordinator)
+        <br/>
+        Academies' project
+        <a class="more" href="http://www.bbaw.de/en/research/aew">
+          Strukturen und Transformationen des Wortschatzes der ägyptischen Sprache. Text- und Wissenskultur im alten Ägypten
+        </a>
+        <br/>
+        Berlin-Brandenburgische Akademie der Wissenschaften<br/>
+        Unter den Linden 8<br/>
+        10117 Berlin
+      </address>
+    </section>
+  </section>
 
-  </body>
-</html>
+  <section>
+    <h2>Technical realisation:</h2>
+    <p>
+      Backend: Jakob Höper<br/>
+      Frontend: Jakob Höper, Daniel A. Werning
+    </p>
+
+    <h3>Basic design:</h3>
+    <p>
+      Thorsten Probst,
+      <a href="http://www.angenehme-gestaltung.de/">angenehme-gestaltung</a>
+    </p>
+  </section>
+
+  <section>
+    <h2>Webmaster:</h2>
+    <p>
+      <a href="mailto:aegypt@bbaw.de?subject=TLA%20homepage">aegypt@bbaw.de</a>
+      <br/>
+      The <strong>design and implementation</strong> of this website are subject to copyright protection.
+      If you wish to use any part of it, please contact: <a href="http://www.bbaw.de/die-akademie/mitarbeiter/werning" target="_blank">Daniel Werning</a>.
+      For the license of the <strong>scientific content</strong>, see the <a href="/info/license">license information</a>.
+    </p>
+
+    <p>
+      The responsible editor and his team make every effort to ensure that information is accurate, but they can accept no legal liability for this.
+      For questions and suggestions on content, please contact: <a href="http://www.bbaw.de/die-akademie/mitarbeiter/werning" target="_blank">Daniel Werning</a>;
+      for technical questions please contact: <a href="http://www.bbaw.de/die-akademie/mitarbeiter/jhoeper" target="_blank">Jakob Höper</a>.
+    </p>
+  </section>
+
+</article>

--- a/src/main/resources/pages/en/legal/privacy.html
+++ b/src/main/resources/pages/en/legal/privacy.html
@@ -1,0 +1,249 @@
+<article>
+
+  <h1>Privacy Policy</h1>
+  <p>
+    The <i>Thesaurus Linguae Aegyptiae</i> is a website published by the Academies's project
+    <i>Strukturen und Transformationen des Wortschatzes der ägyptischen Sprache</i>
+    (henceforth <i>Wortschatz</i> project) at the Berlin-Brandenburgische Akademie der Wissenschaften (BBAW),
+    as part of the Berlin-Brandenburgische Akademie der Wissenschaften (BBAW) website.
+    This privacy policy will explain how we use the personal data we collect from you when you use our website.
+  </p>
+
+  <section>
+    <h2>Topics:</h2>
+    <nav>
+      <ul>
+        <a href="#ip"><li>Internet Protocoll data</li></a>
+        <a href="#collect-what"><li>What data do we collect?</li></a>
+        <a href="#collect-how"><li>How do we collect your data?</li></a>
+        <a href="#use"><li>How will we use your data?</li></a>
+        <a href="#store"><li>How do we store your data?</li></a>
+        <a href="#marketing"><li>Marketing: Project newsletter</li></a>
+        <a href="#protection"><li>What are your data protection rights?</li></a>
+        <a href="#cookies"><li>Cookies</li></a>
+        <a href="#3rd-party"><li>Privacy policies of other websites</li></a>
+        <a href="#changes"><li>Changes to our privacy policy</li></a>
+        <a href="#contact"><li>Contact</li></a>
+      </ul>
+    </nav>
+  </section>
+
+  <section id="ip">
+    <h2>Internet Protocoll data</h2>
+    <p>
+      Every time the domain <b>bbaw.de</b> of the Berlin-Brandenburgische Akademie der Wissenschaften (BBAW)
+      is accessed by a user and every time a file is downloaded, for technical reasons data relating to this procedure
+      are temporarily saved and processed in a protocol file.
+    </p>
+    <p>
+      Specifically, at every access/download, the following data are saved:
+    </p>
+    <ul>
+      <li>the IP address, which is (subsequently) anonymised,</li>
+      <li>date and time,</li>
+      <li>page accessed / name of file downloaded,</li>
+      <li>quantity of data transferred,</li>
+      <li>a message on whether the access/download was successful.</li>
+    </ul>
+    <p>
+      These data are evaluated only for statistical purposes and to improve the quality of service and are then destroyed.
+      No other use is made of them and they are not passed to third-parties.
+    </p>
+  </section>
+
+  <section id="collect-what">
+    <h2>What data do we collect?</h2>
+    <p>
+      The <i>Wortschatz</i> project collects the following data:
+    </p>
+    <ul>
+      <li>Personal identification information (name, email address) and your feedback comments in case you use the feedback form.</li>
+      <li>Your personal choice of the state of functional buttons (e.g., whether you would like to see the hieroglyphs or not).</li>
+    </ul>
+  </section>
+
+  <section id="collect-how">
+    <h2>How do we collect your data?</h2>
+    <p>
+      You directly provide the <i>Wortschatz</i> project with most of the data we collect. We collect data and process data when you:
+    </p>
+    <ul>
+      <li>Use the feedback form (name, email address, comment).</li>
+      <li>Use or view our website and accept the usage of your browser’s cookies.</li>
+    </ul>
+  </section>
+
+  <section id="use">
+    <h2>How will we use your data?</h2>
+    <p>
+      The <i>Wortschatz</i> project collects your data so that we can:
+    </p>
+    <ul>
+      <li>Process your comments and contact you by email (feedback form).</li>
+    </ul>
+    <p>
+      When the <i>Wortschatz</i> project processes your feedback, it may send your data to third persons that are directely concerned,
+      e.g. authors of the data that you refer to.
+    </p>
+  </section>
+
+  <section id="store">
+    <h2>How do we store your data?</h2>
+    <p>
+      The <i>Wortschatz</i> project securely stores your feedback data in the BBAW mailing system or on BBAW internal hard drives.
+    </p>
+    <p>
+      The <i>Wortschatz</i> project will keep your feedback data for internal docomentary purposes or until you request to delete them.
+    </p>
+  </section>
+
+  <section id="marketing">
+    <h2>Marketing: Project Newsletter</h2>
+    <p>
+      The <i>Wortschatz</i> project would like to send you news about the website to the email address that you provide in the feedback form.
+    </p>
+    <p>
+      You have the right at any time to stop the <i>Wortschatz</i> project from contacting you.
+    </p>
+    <p>
+      If you no longer wish to receive news, please reply to the news email and opt out.
+    </p>
+  </section>
+
+  <section id="protection">
+    <h2>What are your data protection rights?</h2>
+    <p>
+      The <i>Wortschatz</i> project would like to make sure you are fully aware of all of your data protection rights.
+      Every user is entitled to the following:
+    </p>
+    <ul>
+      <li>
+        <strong>The right to access</strong>
+        – You have the right to request the <i>Wortschatz</i> project for copies of your personal data. We may charge you a small fee for this service.
+      </li>
+      <li>
+        <strong>The right to rectification</strong>
+        – You have the right to request that the <i>Wortschatz</i> project correct any information you believe is inaccurate.
+        You also have the right to request the <i>Wortschatz</i> project to complete the information you believe is incomplete.
+      </li>
+      <li><strong>The right to erasure</strong> – You have the right to request that the <i>Wortschatz</i> project erase your personal data, under certain conditions.</li>
+      <li><strong>The right to restrict processing</strong> – You have the right to request that the <i>Wortschatz</i> project restrict the processing of your personal data, under certain conditions.</li>
+      <li><strong>The right to object to processing</strong> – You have the right to object to the <i>Wortschatz</i> project’s processing of your personal data, under certain conditions.</li>
+      <li><strong>The right to data portability</strong> – You have the right to request that the <i>Wortschatz</i> project transfer the data that we have collected to another organization, or directly to you, under certain conditions.</li>
+    </ul>
+    <p>
+      If you make a request, we have one month to respond to you.
+      If you would like to exercise any of these rights,
+      please contact us at our email: aegypt@bbaw.de
+    </p>
+    <p>
+      Call us at: +49-30-20370-478 (secretary's office)
+    </p>
+    <p>
+      Or write to us: BBAW, Wortschatz der ägyptischen Sprache / Jägerstraße 22/23 / 10117 Berlin / Germany
+    </p>
+  </section>
+
+  <section id="cookies">
+    <h2>Cookies</h2>
+    <p>
+      Cookies are text files placed on <em>your</em> computer to collect standard Internet log information and visitor behavior information.
+    </p>
+    <p>
+      For further information, visit allaboutcookies.org.
+    </p>
+
+    <section>
+      <h2>How do we use cookies?</h2>
+      <p>
+        If you aggree, the <i>Wortschatz</i> project uses cookies to improve your experience on our website, notably:
+      </p>
+      <ul>
+        <li>
+          Storing the settings of 'visibility' buttons, radiobuttons, checkboxes, etc. (e.g., visibility of information like hieroglyphs,
+          choice of translation language).
+        </li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>What types of cookies do we use?</h2>
+      <p>
+        There are a number of different types of cookies, however, our website uses:
+      </p>
+      <ul>
+        <li>Functionality cookies – The <i>Wortschatz</i> project uses these cookies so that we remember your previously selected preferences. These could include, e.g., what language you prefer. <!--and location you are in. A mix of first-party and third-party cookies are used.--></li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>How to manage cookies</h2>
+      <p>
+        You can choose not to accept the <i>Wortschatz</i> project's cookies.
+      </p>
+    </section>
+  </section>
+
+  <section id="3rd-party">
+    <h2>Privacy policies of other websites</h2>
+    <p>
+      The <i>Wortschatz</i> project website contains links to other websites.
+      Our privacy policy applies only to our website, so if you click on a link to another website,
+      you should read their privacy policy.
+    </p>
+  </section>
+
+  <section id="changes">
+    <h2>Changes to our privacy policy</h2>
+    <p>
+      The <i>Wortschatz</i> project keeps its privacy policy under regular review and places any updates on this web page.
+      This privacy policy was last updated on <time datetime="2019-10-30">30 October 2019</time>.
+    </p>
+  </section>
+
+  <section id="contact">
+    <h2>Contact</h2>
+    <section>
+      <h3>How to contact us</h3>
+      <p>
+        If you have any questions about the <i>Wortschatz</i> project’s privacy policy, the data we hold on you,
+        or you would like to exercise one of your data protection rights, please do not hesitate to contact us.
+      </p>
+      <p>
+        Email us at: <a href="mailto:aegypt@bbaw.de">aegypt@bbaw.de</a>
+      </p>
+      <p>
+        Call us: <a href="tel:+4930-20370-478">+49-30-20370-478</a> (secretary's office)
+      </p>
+      <p>
+        Or write to us at:
+        BBAW,
+        Wortschatz der ägyptischen Sprache,
+        Jägerstraße 22/23,
+        10117 Berlin,
+        Germany
+      </p>
+    </section>
+
+    <section>
+      <h3>How to contact the appropriate authority</h3>
+      <p>
+        Should you wish to report a complaint or if you feel that the <i>Wortschatz</i> project has not addressed your concern in a satisfactory manner,
+        you may contact the Commissioner for Data Protection of the BBAW:
+      </p>
+      <address>
+        <p>
+          Prof. Dr. Matthäus Heil</p>
+        <p>
+          Email: <a href="mailto:heil@bbaw.de">heil@bbaw.de</a></p>
+        <p>
+          BBAW,
+          Incriptiones Graecae,
+          Jägerstraße 22/23,
+          10117 Berlin,
+          Germany
+        </p>
+      </address>
+    </section>
+  </section>
+</article>

--- a/src/main/resources/static/css/tla-styles.css
+++ b/src/main/resources/static/css/tla-styles.css
@@ -1075,6 +1075,25 @@ span.multiselect-native-select select {
 
 
 
+#editorial-content section {
+    margin-bottom: 2rem;
+}
+
+#editorial-content h1 {
+    font-size: 2rem;
+    margin: 1rem 0;
+}
+
+#editorial-content h2 {
+    font-size: 1.4rem;
+    margin: .7rem 0;
+}
+
+#editorial-content h3 {
+    font-size: 1.3rem;
+    margin: .4rem 0;
+}
+
 
 /**************/
 /* Smartphone */

--- a/src/main/resources/templates/editorial.html
+++ b/src/main/resources/templates/editorial.html
@@ -2,8 +2,8 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      xml:lang="en"
       layout:decorate="~{base}"
+      th:lang="${contentLang}"
 >
   <head>
     <title th:text="${env.appName}">Title</title>
@@ -13,8 +13,8 @@
     <div layout:fragment="content">
 
       <div class="row">
-        <div class="col-sm-12 col-lg-8" id="details-content">
-          <th:block th:include="'../pages/en' + ${templatePath} :: body"/>
+        <div class="col-sm-12 col-lg-12" id="editorial-content">
+          <th:block th:insert="~{ ${templatePath} :: body }"/>
         </div>
       </div>
     </div>

--- a/src/main/resources/templates/editorial.html
+++ b/src/main/resources/templates/editorial.html
@@ -14,7 +14,7 @@
 
       <div class="row">
         <div class="col-sm-12 col-lg-8" id="details-content">
-          <th:block th:include="'en' + ${templatePath} :: body"/>
+          <th:block th:include="'../pages/en' + ${templatePath} :: body"/>
         </div>
       </div>
     </div>

--- a/src/main/resources/templates/editorial.html
+++ b/src/main/resources/templates/editorial.html
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xml:lang="en"
+      layout:decorate="~{base}"
+>
+  <head>
+    <title th:text="${env.appName}">Title</title>
+  </head>
+  <body>
+
+    <div layout:fragment="content">
+
+      <div class="row">
+        <div class="col-sm-12 col-lg-8" id="details-content">
+          <th:block th:include="'en' + ${templatePath} :: body"/>
+        </div>
+      </div>
+    </div>
+
+  </body>
+</html>

--- a/src/main/resources/templates/editorial.html
+++ b/src/main/resources/templates/editorial.html
@@ -14,7 +14,7 @@
 
       <div class="row">
         <div class="col-sm-12 col-lg-12" id="editorial-content">
-          <th:block th:insert="~{ ${templatePath} :: body }"/>
+          <th:block th:insert="~{ ${templatePath} :: //article }"/>
         </div>
       </div>
     </div>

--- a/src/main/resources/templates/fragments/common.html
+++ b/src/main/resources/templates/fragments/common.html
@@ -62,15 +62,15 @@
               <br/>
               Strukturen und Transformationen des Wortschatzes der &#xE4;gyptischen Sprache
               <br/><br/>
-              <a href="/">https://tla.bbaw.de</a>
+              <a href="/" th:text="${env.baseUrl}">https://tla.bbaw.de</a>
             </address>
           </div>
           <div class="col-sm-4 col-lg-2 contact">
             <a href="/contact" target="_blank">Contact</a>
             <br/>
-            <a href="/imprint" target="_blank">Imprint</a>
+            <a href="/legal/imprint" target="_blank">Imprint</a>
             <br/>
-            <a href="/privacy-policy" target="_blank">Privacy policy</a>
+            <a href="/legal/privacy" target="_blank">Privacy policy</a>
             <br/>
             <span id="cookie-info">(Cookies not yet accepted)</span>
           </div>

--- a/src/test/java/tla/web/mvc/EditorialPagesTest.java
+++ b/src/test/java/tla/web/mvc/EditorialPagesTest.java
@@ -1,0 +1,100 @@
+package tla.web.mvc;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.ResultActions;
+
+import tla.web.config.EditorialConfig.EditorialRegistry;
+
+@SpringBootTest
+public class EditorialPagesTest extends ViewTest {
+
+    static final String NO_SUPPORT_LANG = "es";
+
+    @Autowired
+    private EditorialRegistry pages;
+
+    @Test
+    void registryAvailable() {
+        assertAll("editorial registry properly injected",
+            () -> assertNotNull(pages),
+            () -> assertEquals(2, pages.getLangSupport().keySet().size(), "2 pages"),
+            () -> assertEquals(
+                Set.of("de", "en"),
+                pages.getSupportedLanguages("/legal/imprint"),
+                "languages in which imprint is available"
+            )
+        );
+    }
+
+    @Override
+    void testLocalization(ResultActions testResponse, String lang) throws Exception {
+        super.testLocalization(testResponse, lang);
+        testResponse.andExpect(
+            header().exists(HttpHeaders.CONTENT_LANGUAGE)
+        // ).andExpect(
+        //     header().string(HttpHeaders.CONTENT_LANGUAGE, lang)  // spring seems to snatch specified content lang somehow so ignore it for the time being
+        ).andExpect(
+            model().attribute("contentLang", lang)
+        ).andExpect(
+            xpath("/html/@lang").string(lang)
+        );
+    }
+
+    @Test
+    void testEditorials() throws Exception {
+        for (Entry<String, Set<String>> e : pages.getLangSupport().entrySet()) {
+            openEditorial(
+                e.getKey(), new LinkedList<>(e.getValue())
+            );
+        }
+    }
+
+    private void openEditorial(String path, List<String> languages) throws Exception {
+        assertTrue(languages.size() > 0, "at least one language supported");
+        for (String lang : languages) {
+            ResultActions test = mockMvc.perform(
+                get(
+                    String.format("/%s", path)
+                ).header(
+                    HttpHeaders.ACCEPT_LANGUAGE, lang
+                )
+            ).andDo(
+                print()
+            ).andExpect(
+                model().attributeExists("env")
+            );
+            testLocalization(test, lang);
+        }
+    }
+
+    @Test
+    void acceptedLanguageUnsupported() throws Exception {
+        ResultActions test = mockMvc.perform(
+            get(
+                "/legal/imprint"
+            ).header(
+                HttpHeaders.ACCEPT_LANGUAGE, NO_SUPPORT_LANG
+            )
+        ).andDo(
+            print()
+        );
+        testLocalization(test, "en"); // TODO default
+    }
+
+}

--- a/src/test/java/tla/web/mvc/SearchFormTest.java
+++ b/src/test/java/tla/web/mvc/SearchFormTest.java
@@ -1,12 +1,5 @@
 package tla.web.mvc;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
-
-import tla.web.config.LemmaSearchProperties;
-
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -16,17 +9,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.List;
 import java.util.Map.Entry;
 
-import org.springframework.http.HttpHeaders;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.ResultActions;
+
+import tla.web.config.LemmaSearchProperties;
 
 @SpringBootTest
 public class SearchFormTest extends ViewTest {
-
-    @Autowired
-    private MockMvc mockMvc;
 
     @Autowired
     private LemmaSearchProperties searchConf;

--- a/src/test/java/tla/web/mvc/ViewTest.java
+++ b/src/test/java/tla/web/mvc/ViewTest.java
@@ -20,6 +20,10 @@ public class ViewTest {
     protected MockMvc mockMvc;
 
     void testLocalization(ResultActions testResponse, Language lang) throws Exception {
+        testLocalization(testResponse, lang.toString());
+    }
+
+    void testLocalization(ResultActions testResponse, String lang) throws Exception {
         testResponse.andExpect(
             content().string(
                 not(containsString(


### PR DESCRIPTION
## problem:

Hosting *"statische Texte"* should allow for:
1. maintainable `l10n` (future release)
2. easy replacement of included facts & figures like e.g. `{percentage_of_texts_with_translation_in_french}`
3. request mapping (page `/legal/imprint.html` should be accessable via `/legal/imprint`

Approx. 3 approaches discussed:
- bundling editorial pages as purely static assets, compute facts using ajax
- writing simple templates, insert whole paragraphs as `message.properties` labels
- write 1 template fragment for each `l10n` language

## solution:

Write 1 template fragment for each language, scan fragments at startup, register language indicators found, create request mapping handler definitions at runtime, negotiate response content language for each request based on registry.

- Editorial pages are being put in `.html` files expected to contain an `<article>` element wrapping all of the respective content.
- `.html` files get stored inside of `src/main/resources/pages/` with the first segment of their path relative to that location indicating the language in which they are written. e.g. `src/main/resources/pages/en/legal/imprint.html`
- The location `src/main/resources/pages/` is defined in the `tla.editorials.path` application property.