### PR TITLE
Run xmllint in CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,6 +12,12 @@ jobs:
     - name: checkout code
       uses: actions/checkout@v2
 
+    - name: install xmllint
+      run: sudo apt-get install --no-install-recommends -y libxml2-utils
+
+    - name: validate editorials
+      run: find src/main/resources -type f -iname "*.html" -exec xmllint --noout {} \;
+
     - name: set up jdk
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,8 +15,8 @@ jobs:
     - name: install xmllint
       run: sudo apt-get install --no-install-recommends -y libxml2-utils
 
-    - name: validate editorials
-      run: find src/main/resources -type f -iname "*.html" -exec xmllint --noout {} \;
+    - name: validate HTML templates
+      run: find src/main/resources/{templates,pages} -type f -iname "*.html" -exec xmllint --noout {} \;
 
     - name: set up jdk
       uses: actions/setup-java@v1

--- a/src/main/resources/pages/en/contact.html
+++ b/src/main/resources/pages/en/contact.html
@@ -1,7 +1,7 @@
 <article>
 			<p>If you have any questions or comments about the <i>Thesaurus Linguae Aegyptiae</i> or its data (if so please refer to an <strong>identifier or URL</strong>), do not hesitate to contact us:
 			<br/><strong>E-mail</strong>: <a href="mailto:aegypt@bbaw.de?subject=TLA%20homepage&amp;body=refers%20to%20page/item:%20xyz">aegypt@bbaw.de</a>
-			<br/><strong>Mail</strong>:
+			</br><strong>Mail</strong>:
 			<address>BBAW, Wortschatz der ägyptischen Sprache / Jägerstraße 22/23 / 10117 Berlin / Germany</address></p>
 			<p><strong>Tip</strong>: If you find the symbol <i class="far fa-comment ml-1 mr-1"></i> on a specific page, you may simply use the contact form which directly refers to the respective page automatically.</p>
 </article>

--- a/src/main/resources/pages/en/contact.html
+++ b/src/main/resources/pages/en/contact.html
@@ -1,7 +1,7 @@
 <article>
 			<p>If you have any questions or comments about the <i>Thesaurus Linguae Aegyptiae</i> or its data (if so please refer to an <strong>identifier or URL</strong>), do not hesitate to contact us:
 			<br/><strong>E-mail</strong>: <a href="mailto:aegypt@bbaw.de?subject=TLA%20homepage&amp;body=refers%20to%20page/item:%20xyz">aegypt@bbaw.de</a>
-			</br><strong>Mail</strong>:
+			<br/><strong>Mail</strong>:
 			<address>BBAW, Wortschatz der ägyptischen Sprache / Jägerstraße 22/23 / 10117 Berlin / Germany</address></p>
 			<p><strong>Tip</strong>: If you find the symbol <i class="far fa-comment ml-1 mr-1"></i> on a specific page, you may simply use the contact form which directly refers to the respective page automatically.</p>
 </article>

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -31,7 +31,7 @@
               <span class="text-monospace" th:text="${url}"/>!
             </span>
           </h6>
-          <div class="my-5"/>
+          <div class="my-5">
             <h2 class="error-msg border-bottom" th:text="#{error_500}">Feherbeschreibung</h2>
             <h6 class="error-msg text-muted" th:text="${msg}" th:if="${#ctx.containsVariable('msg')}">error message</h6>
           </div>

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -31,7 +31,7 @@
               <span class="text-monospace" th:text="${url}"/>!
             </span>
           </h6>
-          <div class="my-5"/>
+          <div class="my-5">
             <h2 class="error-msg border-bottom" th:text="#{error_404}">Feherbeschreibung</h2>
             <h6 class="error-msg text-muted" th:text="${msg}">error message</h6>
           </div>

--- a/src/main/resources/templates/search.html
+++ b/src/main/resources/templates/search.html
@@ -3,26 +3,27 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{base}"
 >
-<body>
-  <div layout:fragment="content">
-    <div class="row search my-4">
-      <div class="col-lg-8">
-        <form th:replace="fragments/search :: #dict-search"/>
-      </div>
+  <body>
+    <div layout:fragment="content">
+      <div class="row search my-4">
+        <div class="col-lg-8">
+          <form th:replace="fragments/search :: #dict-search"/>
+        </div>
 
-      <div class="sidebar col-lg-4">
-        <div class="stick-top">
-          <div>
-            <button class="btn btn-block btn-danger text-left text-decoration-none mt-4" id="submit-dict-search" form="dict-search" type="submit">
-              <span class="fas fa-arrow-circle-right"></span>
-              <span th:text="#{button_label_dict_search}">Search Dict</span>
-            </button>
+        <div class="sidebar col-lg-4">
+          <div class="stick-top">
+            <div>
+              <button class="btn btn-block btn-danger text-left text-decoration-none mt-4" id="submit-dict-search" form="dict-search" type="submit">
+                <span class="fas fa-arrow-circle-right"></span>
+                <span th:text="#{button_label_dict_search}">Search Dict</span>
+              </button>
+            </div>
+            <div th:replace="fragments/search :: clear-form-button(dict-search)"/>
           </div>
-          <div th:replace="fragments/search :: clear-form-button(dict-search)"/>
         </div>
       </div>
+
     </div>
 
-  </div>
-
-</body>
+  </body>
+</html>


### PR DESCRIPTION
Use `xmllint` in CI prior to running tests in order to be able to determine issues with HTML template well-formedness more easily in case tests fail.  Finding any HTML templates that are not well-formed during this step will not abort the CI pipeline tho, because `xmllint` will probably always find some HTML entities to complain about.