### PR TITLE
Lemma ID search and UI improvements

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -70,7 +70,7 @@ jobs:
       uses: "flameddd/screenshots-ci-action@v1.1.1"
       with:
         url: http://localhost:8080/lemma/search/
-        devices: iPhone 6,iPhone 6 landscape,Nexus 7,Pad Pro,Galaxy S III landscape,iPad Pro landscape
+        devices: iPhone 6,iPhone 6 landscape,Nexus 7,iPad Pro,Galaxy S III landscape,iPad Pro landscape
         type: png
 
     - name: upload screenshots
@@ -83,7 +83,7 @@ jobs:
       uses: "flameddd/screenshots-ci-action@v1.1.1"
       with:
         url: http://localhost:8080/lemma/100690
-        devices: iPhone 6,iPhone 6 landscape,Nexus 7,Pad Pro,Galaxy S III landscape,iPad Pro landscape
+        devices: iPhone 6,iPhone 6 landscape,Nexus 7,iPad Pro,Galaxy S III landscape,iPad Pro landscape
         type: png
 
     - name: upload screenshots
@@ -96,7 +96,7 @@ jobs:
       uses: "flameddd/screenshots-ci-action@v1.1.1"
       with:
         url: http://localhost:8080/sentence/IBUBdQmK4memIEBelX9qTCsmuS8#IBUBdzrGyezPxknfiltJIvlQAn0
-        devices: iPhone 6,iPhone 6 landscape,Nexus 7,Pad Pro,Galaxy S III landscape,iPad Pro landscape
+        devices: iPhone 6,iPhone 6 landscape,Nexus 7,iPad Pro,Galaxy S III landscape,iPad Pro landscape
         type: png
 
     - name: upload screenshots
@@ -109,7 +109,7 @@ jobs:
       uses: "flameddd/screenshots-ci-action@v1.1.1"
       with:
         url: http://localhost:8080/thesaurus/7pupjz
-        devices: iPhone 6,iPhone 6 landscape,Nexus 7,Pad Pro,Galaxy S III landscape,iPad Pro landscape
+        devices: iPhone 6,iPhone 6 landscape,Nexus 7,iPad Pro,Galaxy S III landscape,iPad Pro landscape
         type: png
 
     - name: upload screenshots
@@ -122,7 +122,7 @@ jobs:
       uses: "flameddd/screenshots-ci-action@v1.1.1"
       with:
         url: "http://localhost:8080/search?sentence&tokens[0].lemma.id=d2978&tokens[1].lemma.id=10070"
-        devices: iPhone 6,iPhone 6 landscape,Nexus 7,Pad Pro,Galaxy S III landscape,iPad Pro landscape
+        devices: iPhone 6,iPhone 6 landscape,Nexus 7,iPad Pro,Galaxy S III landscape,iPad Pro landscape
         type: png
 
     - name: upload screenshots
@@ -135,7 +135,7 @@ jobs:
       uses: "flameddd/screenshots-ci-action@v1.1.1"
       with:
         url: "http://localhost:8080/sentence/search?tokens[0].lemma.id=74950"
-        devices: iPhone 6,iPhone 6 landscape,Nexus 7,Pad Pro,Galaxy S III landscape,iPad Pro landscape
+        devices: iPhone 6,iPhone 6 landscape,Nexus 7,iPad Pro,Galaxy S III landscape,iPad Pro landscape
         type: png
 
     - name: upload screenshots

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![build](https://github.com/JKatzwinkel/tla-web/workflows/build/badge.svg)
 ![deploy](https://github.com/JKatzwinkel/tla-web/workflows/deploy/badge.svg)
-![LINE](https://img.shields.io/badge/line--coverage-90%25-brightgreen.svg)
+![LINE](https://img.shields.io/badge/line--coverage-89%25-brightgreen.svg)
 ![METHOD](https://img.shields.io/badge/method--coverage-83%25-brightgreen.svg)
 
 TLA web frontend.

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = 'org.bbaw.aaew.tla'
-version = '0.0.810'
+version = '0.0.811'
 sourceCompatibility = '11'
 
 ext {
@@ -202,6 +202,10 @@ task cleanAssets(type: Delete) {
 
 clean {
     dependsOn 'cleanInstall'
+}
+
+springBoot {
+    buildInfo()
 }
 
 bootJar {

--- a/build.gradle
+++ b/build.gradle
@@ -84,9 +84,9 @@ dependencies {
     implementation 'com.github.jkatzwinkel:tla-common:query-expansion-SNAPSHOT'
     implementation 'com.github.rosmord.jsesh:jsesh:release-7.5.5'
 
-    testImplementation 'org.seleniumhq.selenium:selenium-remote-driver:4.0.0-beta-1'
-    testImplementation 'org.seleniumhq.selenium:selenium-chrome-driver:4.0.0-beta-1'
-    testImplementation 'org.seleniumhq.selenium:selenium-support:4.0.0-beta-1'
+    testImplementation 'org.seleniumhq.selenium:selenium-remote-driver:4.0.0-beta-2'
+    testImplementation 'org.seleniumhq.selenium:selenium-chrome-driver:4.0.0-beta-2'
+    testImplementation 'org.seleniumhq.selenium:selenium-support:4.0.0-beta-2'
     testImplementation 'org.testcontainers:selenium:1.15.2'
     testImplementation 'org.testcontainers:junit-jupiter:1.15.2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test:2.5.0-M3'

--- a/build.gradle
+++ b/build.gradle
@@ -6,19 +6,19 @@ plugins {
     id 'maven-publish'
     id 'co.uzzu.dotenv.gradle' version '1.1.0'
     id 'de.undercouch.download' version '4.1.1'
-    id 'org.springframework.boot' version '2.4.3'
-    id 'com.github.ben-manes.versions' version '0.36.0'
+    id 'org.springframework.boot' version '2.4.4'
+    id 'com.github.ben-manes.versions' version '0.38.0'
     id 'com.github.dawnwords.jacoco.badge' version '0.2.0'
 }
 
 group = 'org.bbaw.aaew.tla'
-version = '0.0.811'
+version = '0.0.812'
 sourceCompatibility = '11'
 
 ext {
     fontawesomeVersion = env.FONTAWESOME_VERSION.orElse('5.12.1')
-    bootstrapVersion = env.BOOTSTRAP_VERSION.orElse('4.4.1')
-    jqueryVersion = env.JQUERY_VERSION.orElse('3.5.1')
+    bootstrapVersion = env.BOOTSTRAP_VERSION.orElse('4.6.0')
+    jqueryVersion = env.JQUERY_VERSION.orElse('3.6.0')
     cookieJsVersion = env.COOKIEJS_VERSION.orElse('2.2.1')
     fontawesomeSrc = "https://use.fontawesome.com/releases/v${fontawesomeVersion}/fontawesome-free-${fontawesomeVersion}-web.zip"
     bootstrapSrc = "https://github.com/twbs/bootstrap/releases/download/v${bootstrapVersion}/bootstrap-${bootstrapVersion}-dist.zip"
@@ -69,16 +69,16 @@ dependencies {
     implementation 'org.modelmapper:modelmapper:2.3.9'
     implementation 'org.jooq:jool:0.9.14'
 
-    implementation 'org.springframework.boot:spring-boot-starter-web:2.5.0-M2'
-    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf:2.5.0-M2'
+    implementation 'org.springframework.boot:spring-boot-starter-web:2.5.0-M3'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf:2.5.0-M3'
     implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect:2.5.2'
     implementation 'org.slf4j:slf4j-simple:2.0.0-alpha1'
-    implementation 'org.apache.commons:commons-lang3:3.11'
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
 
     implementation 'com.github.jkatzwinkel:tla-common:query-expansion-SNAPSHOT'
     implementation 'com.github.rosmord.jsesh:jsesh:release-7.5.5'
 
-    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.5.0-M2'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.5.0-M3'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.0-M1'
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/tla/web/mvc/EditorialContentController.java
+++ b/src/main/java/tla/web/mvc/EditorialContentController.java
@@ -1,5 +1,7 @@
 package tla.web.mvc;
 
+import static tla.web.mvc.GlobalControllerAdvisor.BREADCRUMB_HOME;
+
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -32,6 +34,7 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
 
 import lombok.extern.slf4j.Slf4j;
 import tla.web.config.EditorialConfig.EditorialRegistry;
+import tla.web.model.ui.BreadCrumb;
 
 /**
  * Uses dynamic mappings to handle requests for quote unquote "<em>static</em>" pages.
@@ -106,13 +109,10 @@ public class EditorialContentController {
     }
 
     /**
-     * Looks up the page title as defined in <code>messages.properties</code>.
-     *
-     * Example: Title for <code>legal/imprint</code> is defined via message key
-     * <code>editorial_title_legal_imprint</code>.
+     * build i18n message key for an editorial page's title.
      */
-    public String getPageTitle(String path, String lang) {
-        String msgKey = "editorial_title_" + Seq.toString(
+    public static String getPageTitleMsgKey(String path, String lang) {
+        return "editorial_title_" + Seq.toString(
             Stream.of(
                 path.split("/")
             ).filter(
@@ -120,8 +120,17 @@ public class EditorialContentController {
             ),
             "_"
         );
+    }
+
+    /**
+     * Looks up the page title as defined in <code>messages.properties</code>.
+     *
+     * Example: Title for <code>legal/imprint</code> is defined via message key
+     * <code>editorial_title_legal_imprint</code>.
+     */
+    public String getPageTitle(String path, String lang) {
         return l10n.getMessage(
-            msgKey,
+            getPageTitleMsgKey(path, lang),
             null,
             path,
             new Locale(lang)
@@ -170,6 +179,15 @@ public class EditorialContentController {
         model.addAttribute(
             "pageTitle",
             getPageTitle(path, contentLang)
+        );
+        model.addAttribute(
+            "breadcrumbs",
+            List.of(
+                BREADCRUMB_HOME,
+                BreadCrumb.of(
+                    getPageTitleMsgKey(path, lang)
+                )
+            )
         );
         return "editorial";
     }

--- a/src/main/java/tla/web/mvc/EditorialContentController.java
+++ b/src/main/java/tla/web/mvc/EditorialContentController.java
@@ -2,6 +2,7 @@ package tla.web.mvc;
 
 import java.lang.reflect.Method;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
@@ -92,7 +93,9 @@ public class EditorialContentController {
      */
     private HttpHeaders preferContentLanguage(String lang, HttpHeaders header) {
         if (lang != null && TLALocaleResolver.isValidContentLanguage(lang)) {
-            List<Locale.LanguageRange> requested = header.getAcceptLanguage();
+            List<Locale.LanguageRange> requested = new ArrayList<>(
+                header.getAcceptLanguage()
+            );
             requested.add(
                 0,
                 new Locale.LanguageRange(lang, 1.0f)

--- a/src/main/java/tla/web/mvc/EditorialContentController.java
+++ b/src/main/java/tla/web/mvc/EditorialContentController.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -19,6 +20,7 @@ import org.springframework.context.event.EventListener;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -48,6 +50,11 @@ public class EditorialContentController {
 
     @Value("${tla.editorials.path}")
     private String editorialsDir;
+
+    @ModelAttribute("build")
+    public Map<String, String> buildInfo() {
+        return Map.of();
+    }
 
     /**
      * Select one of the languages in which a requested editorial page is available

--- a/src/main/java/tla/web/mvc/GlobalControllerAdvisor.java
+++ b/src/main/java/tla/web/mvc/GlobalControllerAdvisor.java
@@ -25,6 +25,8 @@ import tla.web.model.ui.BreadCrumb;
 @ControllerAdvice
 public class GlobalControllerAdvisor extends DefaultHandlerExceptionResolver {
 
+    public static final BreadCrumb BREADCRUMB_HOME = BreadCrumb.of("/", "menu_global_home");
+
     @Autowired
     private BuildProperties buildProperties;
 
@@ -48,7 +50,7 @@ public class GlobalControllerAdvisor extends DefaultHandlerExceptionResolver {
     @ModelAttribute("breadcrumbs")
     public List<BreadCrumb> basicBreadcrumb() {
         return List.of(
-            BreadCrumb.of("/", "menu_global_home")
+            BREADCRUMB_HOME
         );
     }
 
@@ -62,7 +64,7 @@ public class GlobalControllerAdvisor extends DefaultHandlerExceptionResolver {
         model.addAttribute(
             "breadcrumbs",
             List.of(
-                BreadCrumb.of("/", "menu_global_home"),
+                BREADCRUMB_HOME,
                 BreadCrumb.of("/search", "menu_global_search")
             )
         );

--- a/src/main/java/tla/web/mvc/GlobalControllerAdvisor.java
+++ b/src/main/java/tla/web/mvc/GlobalControllerAdvisor.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
@@ -23,6 +25,9 @@ import tla.web.model.ui.BreadCrumb;
 @ControllerAdvice
 public class GlobalControllerAdvisor extends DefaultHandlerExceptionResolver {
 
+    @Autowired
+    private BuildProperties buildProperties;
+
     private ApplicationProperties applicationProperties;
 
     public GlobalControllerAdvisor(ApplicationProperties properties) {
@@ -35,7 +40,8 @@ public class GlobalControllerAdvisor extends DefaultHandlerExceptionResolver {
             "baseUrl", applicationProperties.getBaseUrl(),
             "appName", applicationProperties.getName(),
             "l10n", applicationProperties.getL10n(),
-            "lang", LocaleContextHolder.getLocale().getLanguage()
+            "lang", LocaleContextHolder.getLocale().getLanguage(),
+            "version", buildProperties.getVersion()
         );
     }
 

--- a/src/main/java/tla/web/mvc/ObjectController.java
+++ b/src/main/java/tla/web/mvc/ObjectController.java
@@ -159,10 +159,13 @@ public abstract class ObjectController<T extends TLAObject, S extends SearchComm
      */
     @RequestMapping(value = "/autocomplete", method = RequestMethod.GET)
     public ResponseEntity<?> autoComplete(
-        @RequestParam String term, @RequestParam(required = false) Optional<String> type
+        @RequestParam(required = false) Optional<String> term,
+        @RequestParam(required = false) Optional<String> type
     ) {
         log.info("term: {}", term);
-        return getService().autoComplete(term, type.orElse(""));
+        return getService().autoComplete(
+            term.orElse(""), type.orElse("")
+        );
     }
 
     /**

--- a/src/main/java/tla/web/mvc/ObjectController.java
+++ b/src/main/java/tla/web/mvc/ObjectController.java
@@ -5,8 +5,10 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.ui.Model;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -150,6 +152,18 @@ public abstract class ObjectController<T extends TLAObject, S extends SearchComm
      * required by this controller.
      */
     public abstract ObjectService<T> getService();
+
+    /**
+     * Passes the <code>?term</code> URL parameter value through to an <code>/complete</code>
+     * autocomplete endpoint of the backend application and return back with its JSON response.
+     */
+    @RequestMapping(value = "/autocomplete", method = RequestMethod.GET)
+    public ResponseEntity<?> autoComplete(
+        @RequestParam String term, @RequestParam(required = false) Optional<String> type
+    ) {
+        log.info("term: {}", term);
+        return getService().autoComplete(term, type.orElse(""));
+    }
 
     /**
      * Retrieves the requested plus relevant related entites, and renders the results into the

--- a/src/main/java/tla/web/mvc/ObjectController.java
+++ b/src/main/java/tla/web/mvc/ObjectController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.view.RedirectView;
 
 import lombok.extern.slf4j.Slf4j;
 import tla.domain.command.SearchCommand;
@@ -162,9 +163,23 @@ public abstract class ObjectController<T extends TLAObject, S extends SearchComm
         @RequestParam(required = false) Optional<String> term,
         @RequestParam(required = false) Optional<String> type
     ) {
-        log.info("term: {}", term);
+        log.info("term: {}", term.get());
         return getService().autoComplete(
             term.orElse(""), type.orElse("")
+        );
+    }
+
+    /**
+     * Redirects to object details page, but identifies object by <code>&id</code> URL parameter
+     * instead of path variable.
+     */
+    @RequestMapping(value = "/lookup", method = RequestMethod.GET)
+    public RedirectView lookup(@RequestParam String id) {
+        return new RedirectView(
+            String.format(
+                "%s/%s", this.getRequestMapping(), id
+            ),
+            true
         );
     }
 

--- a/src/main/java/tla/web/mvc/SearchController.java
+++ b/src/main/java/tla/web/mvc/SearchController.java
@@ -15,17 +15,16 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import lombok.extern.slf4j.Slf4j;
 import tla.domain.command.LemmaSearch;
 import tla.domain.command.SentenceSearch;
 import tla.domain.command.SentenceSearch.TokenSpec;
 import tla.domain.model.Language;
 import tla.domain.model.Script;
 import tla.web.config.LemmaSearchProperties;
+import tla.web.model.Lemma;
 import tla.web.model.ui.BreadCrumb;
 import tla.web.model.ui.SearchFormExpansionState;
 
-@Slf4j
 @Controller
 @RequestMapping("/search")
 public class SearchController {
@@ -36,7 +35,7 @@ public class SearchController {
     @Value("${search.config.default}")
     private String defaultForm;
 
-    public static final List<String> SEARCH_FORMS = List.of("dict", "sentence");
+    public static final List<String> SEARCH_FORMS = List.of("lemma-quick", "dict", "sentence");
 
     @ModelAttribute("allScripts")
     public Script[] getAllScripts() {
@@ -60,6 +59,7 @@ public class SearchController {
 
     @RequestMapping(value = "", method = RequestMethod.GET)
     public String mainSearchPage(
+        @ModelAttribute("lemma") Lemma lemma,
         @ModelAttribute("lemmaSearchForm") LemmaSearch lemmaForm,
         @ModelAttribute("sentenceSearchForm") SentenceSearch sentenceForm,
         @RequestParam MultiValueMap<String, String> params,

--- a/src/main/java/tla/web/repo/TlaClient.java
+++ b/src/main/java/tla/web/repo/TlaClient.java
@@ -2,8 +2,10 @@ package tla.web.repo;
 
 import java.lang.annotation.Annotation;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
 import lombok.extern.slf4j.Slf4j;
@@ -67,6 +69,26 @@ public class TlaClient {
             "%s/%s",
             this.backendUrl,
             getBackendPathPrefix(modelClass)
+        );
+    }
+
+    /**
+     * Call backend autocomplete endpoint for given model.
+     * TODO
+     */
+    @SuppressWarnings("rawtypes")
+    public ResponseEntity<List> autoComplete(Class<? extends TLAObject> modelClass, String term, String type) {
+        return client.getForEntity(
+            String.format(
+                "%s/complete?q=%s",
+                this.getEndpointURLPrefix(modelClass),
+                term
+            ),
+            List.class,
+            Map.of(
+                "q", term,
+                "type", type
+            )
         );
     }
 

--- a/src/main/java/tla/web/repo/TlaClient.java
+++ b/src/main/java/tla/web/repo/TlaClient.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriTemplate;
 
 import lombok.extern.slf4j.Slf4j;
 import tla.domain.command.SearchCommand;
@@ -23,6 +24,8 @@ import tla.web.model.meta.TLAObject;
  */
 @Slf4j
 public class TlaClient {
+
+    public static final UriTemplate URI_AUTOCOMPLETE = new UriTemplate("{url}/complete?q={q}&type={type}");
 
     private RestTemplate client;
 
@@ -79,16 +82,14 @@ public class TlaClient {
     @SuppressWarnings("rawtypes")
     public ResponseEntity<List> autoComplete(Class<? extends TLAObject> modelClass, String term, String type) {
         return client.getForEntity(
-            String.format(
-                "%s/complete?q=%s",
-                this.getEndpointURLPrefix(modelClass),
-                term
-            ),
-            List.class,
-            Map.of(
-                "q", term,
-                "type", type
-            )
+            URI_AUTOCOMPLETE.expand(
+                Map.of(
+                    "url", this.getEndpointURLPrefix(modelClass),
+                    "q", term,
+                    "type", type
+                )
+            ).toString(),
+            List.class
         );
     }
 

--- a/src/main/java/tla/web/service/ObjectService.java
+++ b/src/main/java/tla/web/service/ObjectService.java
@@ -4,6 +4,7 @@ import java.lang.annotation.Annotation;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 
 import lombok.extern.slf4j.Slf4j;
 import tla.domain.command.SearchCommand;
@@ -11,6 +12,7 @@ import tla.domain.dto.extern.SearchResultsWrapper;
 import tla.domain.dto.extern.SingleDocumentWrapper;
 import tla.domain.dto.meta.AbstractDto;
 import tla.domain.model.meta.BTSeClass;
+import tla.domain.model.meta.TLADTO;
 import tla.web.config.SearchProperties;
 import tla.web.model.mappings.MappingConfig;
 import tla.web.model.meta.ModelClass;
@@ -35,6 +37,8 @@ public abstract class ObjectService<T extends TLAObject> {
     private Class<T> modelClass;
 
     private SearchProperties searchProperties;
+
+    ResponseEntity<?> EMPTY_RESPONSE = ResponseEntity.of(Optional.empty());
 
     @SuppressWarnings("unchecked")
     public ObjectService() {
@@ -76,6 +80,19 @@ public abstract class ObjectService<T extends TLAObject> {
      */
     public String getModelEClass() {
         return MappingConfig.extractEclass(this.getModelClass());
+    }
+
+    /**
+     * Call appropriate autocomplete endpoint for this service's model class.
+     */
+    public ResponseEntity<?> autoComplete(String term, String type) {
+        if (term.trim().length() > 2) {
+            return backend.autoComplete(
+                this.getModelClass(), term, type
+            );
+        } else {
+            return EMPTY_RESPONSE;
+        }
     }
 
     /**

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -159,9 +159,11 @@ lang_label_en=English
 lang_label_fr=Français
 
 # Search forms
+form_label_lemma-quick-search=Look up Lemma
 form_label_dict-search=Dictionary entries
 form_label_sentence-search=Text corpus
 
+field_label_lemma_id=Lemma ID
 field_label_script=Sub-dictionary
 field_label_transcription=Transliteration
 field_label_translation=Translation
@@ -245,6 +247,7 @@ field_value_label_sort_by_timeSpan.end_desc_type_lemma=Attestation time, end
 field_value_label_sort_by_root_asc_type_lemma=Root
 
 button_label_clear_form=Clear all
+button_label_lemma-quick_search=Go to Lemma
 button_label_dict_search=Search in Dictionary
 button_label_sentence_search=Search Text Corpus
 button_label_modify_search=Modify Search

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -9,6 +9,7 @@ menu_global_search_lemma=Dictionary
 menu_global_search_sentence=Occurrences
 menu_global_help=Help
 
+editorial_title_home=
 editorial_title_contact=Contact
 editorial_title_help=General Help
 editorial_title_help_bts-glossings=BTS glossing

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -8,7 +8,6 @@ menu_global_search=Search
 menu_global_search_lemma=Dictionary
 menu_global_search_sentence=Occurrences
 menu_global_help=Help
-menu_global_lang=Language
 
 editorial_title_contact=Contact
 editorial_title_help=General Help

--- a/src/main/resources/messages_de.properties
+++ b/src/main/resources/messages_de.properties
@@ -7,7 +7,6 @@ menu_global_home=Homepage
 menu_global_search=Suchen
 menu_global_search_lemma=Wörterbuch
 menu_global_search_sentence=Belegstellen
-menu_global_lang=Sprache
 
 editorial_title_contact=Kontakt
 editorial_title_help=Allg. Hilfe

--- a/src/main/resources/messages_de.properties
+++ b/src/main/resources/messages_de.properties
@@ -8,6 +8,7 @@ menu_global_search=Suchen
 menu_global_search_lemma=Wörterbuch
 menu_global_search_sentence=Belegstellen
 
+editorial_title_home=
 editorial_title_contact=Kontakt
 editorial_title_help=Allg. Hilfe
 editorial_title_help_bts-glossings=BTS Glossierung

--- a/src/main/resources/messages_de.properties
+++ b/src/main/resources/messages_de.properties
@@ -153,9 +153,11 @@ lang_label_en=English
 lang_label_fr=Français
 
 # Search forms
+form_label_lemma-quick-search=Lemma nachschlagen
 form_label_dict-search=Wörterbuch
 form_label_sentence-search=Belegstellen
 
+field_label_lemma_id=Lemma-ID
 field_label_script=Teilwörterbuch
 field_label_transcription=Transkription
 field_label_translation=Übersetzung
@@ -235,6 +237,7 @@ field_value_label_sort_by_timeSpan.end_desc_type_lemma=Belegzeit, Ende
 field_value_label_sort_by_root_asc_type_lemma=Wurzel
 
 button_label_clear_form=Alles löschen
+button_label_lemma-quick_search=Lemma öffnen
 button_label_dict_search=Suche im Wörterbuch
 button_label_modify_search=Suche modifizieren
 button_label_hide_property_lemma-id=Lemma-ID

--- a/src/main/resources/static/css/tla-styles.css
+++ b/src/main/resources/static/css/tla-styles.css
@@ -139,6 +139,10 @@ a.navbar-brand {
     color: var(--BBAWmiddlegrey);
 }
 
+.breadcrumb.language > a.active {
+    color: var(--BBAWdarkgrey);
+}
+
 .cookie-wrapper {
     position: fixed;
     left: 0;

--- a/src/main/resources/templates/base.html
+++ b/src/main/resources/templates/base.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html
+    th:lang="${env.lang}"
     xmlns:th="http://www.thymeleaf.org"
     xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
 >

--- a/src/main/resources/templates/fragments/common.html
+++ b/src/main/resources/templates/fragments/common.html
@@ -9,7 +9,10 @@
       <nav class="navbar navbar-expand-lg navbar-light bg-white fixed-top">
         <div class="container">
           <a class="navbar-brand" href="/">TLA</a>
-          <h1 th:text="${env.appName}">Thesaurus Linguae Aegyptiae</h1>
+          <div>
+            <h1 th:text="${env.appName}">Thesaurus Linguae Aegyptiae</h1>
+            <a href="#" th:text="${env.version}">0.1.0</a>
+          </div>
           <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"/>
           </button>

--- a/src/main/resources/templates/fragments/common.html
+++ b/src/main/resources/templates/fragments/common.html
@@ -48,17 +48,6 @@
                   <a class="dropdown-item" href="/help/ling-glossings" th:text="#{editorial_title_help_ling-glossings}">Linguistic glossing</a>
                 </div>
               </li>
-              <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle" href="#" id="langDropdown" role="button"
-                  data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                  <i class="far fa-flag"></i>
-                  <span th:text="#{menu_global_lang}">Language</span>
-                </a>
-                <div class="dropdown-menu" aria-labelledby="langDropdown">
-                  <a th:each="lang : ${env.l10n}" href="#" class="dropdown-item" th:text="#{|lang_label_${lang}}"
-                      th:href="${@templateUtils.setQueryParam('lang', lang)}">English</a>
-                </div>
-              </li>
             </ul>
           </div>
         </div>
@@ -106,9 +95,9 @@
 
     <!-- page breadcrumbs -->
 
-    <div id="breadcrumbs" class="row" th:fragment="breadcrumbs">
-      <div class="col-12">
-        <nav aria-label="breadcrumb">
+    <div id="breadcrumbs" class="row justify-content-center" th:fragment="breadcrumbs">
+      <div class="col-12 d-lg-flex">
+        <nav aria-label="breadcrumb" class="flex-grow-1">
           <ol class="breadcrumb">
             <li th:each="item : ${breadcrumbs}" class="breadcrumb-item" th:classappend="${itemStat.last} ? 'active' : ''">
               <a th:unless="${item.href} == null" th:href="${item.href}" th:text="#{${item.label}}"></a>
@@ -116,6 +105,15 @@
             </li>
           </ol>
         </nav>
+        <div class="language breadcrumb">
+          <th:block th:each="lang, i : ${env.l10n}">
+            <a th:classappend="${env.lang == lang} ? 'active' : ''"
+                th:href="${@templateUtils.setQueryParam('lang', lang)}" th:text="${lang}" class="text-uppercase">
+              EN
+            </a>
+            <i th:unless="${i.last}" class="pl-1 pr-1">|</i>
+          </th:block>
+        </div>
       </div>
     </div>
 

--- a/src/main/resources/templates/fragments/search/forms.html
+++ b/src/main/resources/templates/fragments/search/forms.html
@@ -16,35 +16,13 @@
           <label class="col-form-label col-xl-2" th:text="#{field_label_lemma}">Lemma</label>
           <!--<label class="col-form-label col-xl-1" th:text="${token.empty}"></label>-->
           <div class="col-xl-10">
-            <input class="form-control mb-3" type="text" th:field="*{tokens[__${i.index}__].lemma.id}"
+
+            <input class="form-control mb-3 lemma-id" type="text" th:field="*{tokens[__${i.index}__].lemma.id}"
                 th:id="|token-${i.index}-lemma|" th:list="|token-${i.index}-lemma-suggestions|">
-              <script th:inline="javascript">
-                //<![CDATA[
-                {
-                  let index = /*[[${i.index}]]*/ null;
-                  $(`#token-${index}-lemma`).on('input', (e) => {
-                    $.ajax(
-                      {
-                        url: 'http://localhost:8090/lemma/complete', // TODO
-                        data: {
-                          q: $(`#token-${index}-lemma`).val()
-                        },
-                        success: (result) => {
-                          $(`#token-${index}-lemma-suggestions`).empty();
-                          result.forEach((i) => {
-                            $('<option/>').text(i.name).attr('value', i.id).attr('label', i.name).appendTo(
-                              $(`#token-${index}-lemma-suggestions`)
-                            );
-                          });
-                        }
-                      }
-                    );
-                  });
-                }
-                //]]>
-              </script>
+              <script th:replace="fragments/search/tools :: autocomplete(__|token-${i.index}-lemma|__)"/>
             </input>
             <datalist th:id="|token-${i.index}-lemma-suggestions|"/>
+
           </div>
           <label class="col-form-label col-xl-2" th:text="#{field_label_hieroglyphs}">Hieroglyphs</label>
           <div class="col-xl-10">

--- a/src/main/resources/templates/fragments/search/forms.html
+++ b/src/main/resources/templates/fragments/search/forms.html
@@ -3,6 +3,23 @@
 
   <body>
 
+    <!-- Lemma quick lookup search form -->
+    <form id="lemma-quick-search" name="lemma-quick-search" th:object="${lemma}"
+        th:action="@{/lemma/lookup}" method="get">
+      <fieldset class="form-group row">
+        <label class="col-form-label col-xl-2" th:text="#{field_label_lemma_id}" for="lemma-quick-search-id">
+          Lemma
+        </label>
+        <div class="col-xl-10">
+          <input class="form-control mb-3 lemma-id" type="text" th:field="*{id}"
+              th:id="lemma-quick-search-id" th:list="lemma-quick-search-id-suggestions">
+            <script th:replace="fragments/search/tools :: autocomplete('lemma-quick-search-id')"></script>
+          </input>
+          <datalist th:id="lemma-quick-search-id-suggestions"/>
+        </div>
+      </fieldset>
+    </form>
+
     <!-- sentence/occurrence search form -->
     <form id="sentence-search" name="sentence-search"
     th:action="@{/sentence/search}" th:object="${sentenceSearchForm}" method="get">
@@ -19,11 +36,11 @@
 
             <input class="form-control mb-3 lemma-id" type="text" th:field="*{tokens[__${i.index}__].lemma.id}"
                 th:id="|token-${i.index}-lemma|" th:list="|token-${i.index}-lemma-suggestions|">
-              <script th:replace="fragments/search/tools :: autocomplete(__|token-${i.index}-lemma|__)"/>
+              <script th:replace="fragments/search/tools :: autocomplete(__|token-${i.index}-lemma|__)"></script>
             </input>
             <datalist th:id="|token-${i.index}-lemma-suggestions|"/>
-
           </div>
+
           <label class="col-form-label col-xl-2" th:text="#{field_label_hieroglyphs}">Hieroglyphs</label>
           <div class="col-xl-10">
             <input class="form-control mb-3" type="text" th:field="*{tokens[__${i.index}__].glyphs}"/>

--- a/src/main/resources/templates/fragments/search/tools.html
+++ b/src/main/resources/templates/fragments/search/tools.html
@@ -2,12 +2,13 @@
   //<![CDATA[
   {
     let field = /*[[${field}]]*/ null;
+    let URL = /*[[${(#mvc.url('LC#autoComplete')).build()}]]*/ null;
     $(`#${field}`).on('input', (e) => {
       $.ajax(
         {
-          url: 'http://localhost:8090/lemma/complete', // TODO
+          url: `${URL}`,
           data: {
-            q: $(`#field`).val()
+            term: $(`#${field}`).val()
           },
           success: (result) => {
             $(`#${field}-suggestions`).empty();

--- a/src/main/resources/templates/fragments/search/tools.html
+++ b/src/main/resources/templates/fragments/search/tools.html
@@ -1,0 +1,25 @@
+<script th:fragment="autocomplete(field)" th:inline="javascript">
+  //<![CDATA[
+  {
+    let field = /*[[${field}]]*/ null;
+    $(`#${field}`).on('input', (e) => {
+      $.ajax(
+        {
+          url: 'http://localhost:8090/lemma/complete', // TODO
+          data: {
+            q: $(`#field`).val()
+          },
+          success: (result) => {
+            $(`#${field}-suggestions`).empty();
+            result.forEach((i) => {
+              $('<option/>').text(i.name).attr('value', i.id).attr('label', i.name).appendTo(
+                $(`#${field}-suggestions`)
+              );
+            });
+          }
+        }
+      );
+    });
+  }
+  //]]>
+</script>

--- a/src/test/java/tla/web/mvc/LemmaDetailsTest.java
+++ b/src/test/java/tla/web/mvc/LemmaDetailsTest.java
@@ -138,4 +138,17 @@ public class LemmaDetailsTest extends ViewTest {
         );
     }
 
+    @Test
+    void testLookup() throws Exception {
+        mockMvc.perform(
+            get("/lemma/lookup?id=31610")
+        ).andExpect(
+            status().is3xxRedirection()
+        ).andExpect(
+            header().string(
+                "Location", "/lemma/31610"
+            )
+        );
+    }
+
 }


### PR DESCRIPTION
# 1. Lemma ID search

Add search mode for quick lookup of lemma entries with an autocomplete/search-as-you-type kind of input field (529f794, 86762f2, b1ccb64).

![Screenshot from 2021-04-28 23-51-38](https://user-images.githubusercontent.com/1922142/116478041-cab26780-a87d-11eb-94da-6a02fef4c6b3.png)
---
![Screenshot from 2021-04-28 23-52-19](https://user-images.githubusercontent.com/1922142/116478067-d0a84880-a87d-11eb-8a12-c1a9f3471501.png)
---
![Screenshot from 2021-04-28 23-53-50](https://user-images.githubusercontent.com/1922142/116478077-d43bcf80-a87d-11eb-9887-006370f56520.png)

- fixes https://github.com/thesaurus-linguae-aegyptiae/tla-web/issues/42

---

# 2. Move language switcher

Language selection widget is now in breadcrumbs row (612eec8).

- fixes https://github.com/thesaurus-linguae-aegyptiae/tla-web/issues/36

---

# 3. Breadcrumbs for static pages

Add abstract logic generating breadcrumbs for generic "static" pages with editorial contents (b80034c).

![Screenshot from 2021-04-29 00-06-16](https://user-images.githubusercontent.com/1922142/116478738-dd796c00-a87e-11eb-8f86-7f941f9dd382.png)


- fixes https://github.com/thesaurus-linguae-aegyptiae/tla-web/issues/32
