### PR TITLE
customize codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,5 +11,19 @@
 	},
 	"postCreateCommand": [
 		"apt-get update && apt-get install -y fontconfig"
-	]
+	],
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ryanluker.vscode-coverage-gutters"
+			],
+			"settings": {
+				"editor.renderWhitespace": "all",
+				"coverage-gutters.coverageFileNames": [
+					"jacocoTestReport.xml"
+				],
+				"coverage-gutters.showLineCoverage": true
+			}
+		}
+	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,16 +2,14 @@
 	"name": "Java",
 	"image": "mcr.microsoft.com/devcontainers/java:0-17",
 	"features": {
-		"ghcr.io/devcontainers/features/java:1": {
-			"version": "17",
-			"installMaven": "false",
-			"installGradle": "false"
-		},
 		"ghcr.io/devcontainers/features/github-cli:1": {},
 		"ghcr.io/devcontainers/features/common-utils:2": {
 			"configureZshAsDefaultShell": "true"
 		},
 		"ghcr.io/devcontainers-contrib/features/curl-apt-get:1": {},
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
-	}
+	},
+	"postCreateCommand": [
+		"apt-get update && apt-get install -y fontconfig"
+	]
 }


### PR DESCRIPTION
- rm redundant java feature from java devcontainer
- have `fontconfig` installed inside new codespaces (required by tests)
- have coverage gutters extension added to codespaces and configured for jacoco